### PR TITLE
bug in undelivered segments

### DIFF
--- a/js/data/basalutil.js
+++ b/js/data/basalutil.js
@@ -44,16 +44,15 @@ function BasalUtil(data) {
             // It's a temp, which wins no matter what it was before.
             // Start by setting up shared adjustments to the segments (clone lastActual and reshape it)
             var undeliveredClone = _.clone(lastActual);
+            lastActual.end = e.start;
 
-            if (e.end >= lastActual.end) {
+            if (e.end >= undeliveredClone.end) {
               // The temp segment is longer than the current, throw away the rest of the current
-              lastActual.end = e.start;
               undeliveredClone.start = e.start;
               addToUndelivered(undeliveredClone);
               addToActuals(e);
             } else {
               // The current exceeds the temp, so replace the current "chunk" and re-attach the schedule
-              lastActual.end = e.start;
               var endingSegment = _.clone(undeliveredClone);
               undeliveredClone.start = e.start;
               undeliveredClone.end = e.end;
@@ -72,11 +71,11 @@ function BasalUtil(data) {
             } else {
               // Scheduled overlapping a temp, this can happen and the schedule should be skipped
               var undeliveredClone = _.clone(e);
-              var deliveredClone = _.clone(e);
 
-              if (e.end >= lastActual.end) {
+              if (e.end > lastActual.end) {
                 // Scheduled is longer than the temp, so preserve the tail
-                undeliveredClone.end = e.end;
+                var deliveredClone = _.clone(e);
+                undeliveredClone.end = lastActual.end;
                 deliveredClone.start = lastActual.end;
                 addToUndelivered(undeliveredClone);
                 addToActuals(deliveredClone);

--- a/test/basalutil.js
+++ b/test/basalutil.js
@@ -113,7 +113,9 @@ function testData (data) {
         });
         var undeliveredDuration = 0;
         basal.undelivered.forEach(function(segment) {
-          undeliveredDuration += Date.parse(segment.end) - Date.parse(segment.start);
+          if (segment.deliveryType === 'scheduled') {
+            undeliveredDuration += Date.parse(segment.end) - Date.parse(segment.start);
+          }
         });
         expect(undeliveredDuration).to.equal(tempDuration);
       });


### PR DESCRIPTION
Look, @cheddar, I created a branch for you ;)

There's a bug in the undelivered segments. I think it goes something like this: the last segment of a particular collection of undelivered segments (that is, the collection matching a single temp basal that stretches across two or more scheduled segments) is too long - it stretches to the beginning of the next scheduled segment instead of to the end of the temp segment. This was hard to see the consequences of in the viz because the effect is just the extension of a dotted line _under_ another line, but I do need the undelivered segments to be accurate for filling in the right info in the tooltips.

This is blocking me finishing the basal tooltips, so if you can fix it, that'd be great. Otherwise I'll work on other stuff for a while and come back to it when I can.

Thanks again for your help with this!
