### PR TITLE
Add 'repository' field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "tideline",
+  "repository": {
+      "type" : "git",
+      "url" : "https://github.com/tidepool-org/tideline.git"
+  },
   "version": "0.0.0",
   "dependencies": {
     "duration-js": "3.3.3",


### PR DESCRIPTION
# What? Why?

Mainly to get rid of the warning on `npm install`. 
# How was it tested?

Deleted `./node_modules` and ran `npm install` again. No error message was present.
