### PR TITLE
Make twoWeek.data() more flexible with viewEndDate

### DIFF
--- a/js/two-week.js
+++ b/js/two-week.js
@@ -547,12 +547,14 @@ module.exports = function(emitter) {
     dataEndNoon = new Date(dataEndNoon.toISOString().slice(0,11) + noon);
 
     if (!viewEndDate) {
-      viewEndDate = last;
+      viewEndDate = new Date(days[0]);
+    } else {
+      viewEndDate = new Date(viewEndDate);
     }
+
     var viewBeginning = new Date(viewEndDate);
     viewBeginning.setUTCDate(viewBeginning.getUTCDate() - 14);
     viewEndpoints = [new Date(viewBeginning.toISOString().slice(0,11) + noon), new Date(viewEndDate.toISOString().slice(0,11) + noon)];
-
     viewIndex = days.indexOf(viewEndDate.toISOString().slice(0,10));
 
     container.dataPerDay = [];


### PR DESCRIPTION
Small difficulties I encountered when working with `container.data(data, viewEndDate)` (from `two-week.js`).

If I called it without a `viewEndDate`, it would default to the datetime of the last element of `data`, but that could be outside of the `days` array of the widget. For example, we could have `days = ['2014-03-15', '2014-03-14', '2014-03-13', ...]`, but the last element of `data` could be on `'2014-03-16T10:03:00Z'`.

**Solution**: If no viewEndDate is passed, default to the most recent `days` element.

If I called it with a `viewEndDate` that is a `string` (ex: `'2014-03-15T09:04:00Z'`) vs a `Date` object, then it would error. In `one-day.js`, the `container.locate(datetime)` method allows a string to be given. So, would like to match that for consistency.

**Solution**: If a viewEndDate is passed, allow it to be a string (as well as a Date object).
