### PR TITLE
for discussion of strategy surrounding floating point numbers

### DIFF
--- a/js/data/basalutil.js
+++ b/js/data/basalutil.js
@@ -92,9 +92,13 @@ function BasalUtil(data) {
     }
   }
 
+  function fixFloatingPoint (n) {
+    return parseFloat(n.toFixed(3));
+  }
+
   this.segmentDose = function(duration, rate) {
     var hours = duration / MS_IN_HOUR;
-    return hours * rate;
+    return fixFloatingPoint(hours * rate);
   };
 
   this.totalBasal = function(s, e) {
@@ -115,7 +119,7 @@ function BasalUtil(data) {
       index++;
     }
     dose += this.segmentDose(e - new Date(lastSegment.start), lastSegment.value);
-    return dose;
+    return fixFloatingPoint(dose);
   };
 
   data.forEach(processElement);

--- a/test/basalutil.js
+++ b/test/basalutil.js
@@ -10,8 +10,6 @@ var fx = require('./fixtures');
 
 var BasalUtil = require('../js/data/basalutil');
 
-var EPSILON = 0.00001;
-
 var MS_IN_HOUR = 3600000.0;
 
 fx.forEach(testData);
@@ -139,19 +137,19 @@ describe('totalBasal', function() {
   it('should return 20.0 on basal-template.json for twenty-four hours', function() {
     var start = new Date("2014-02-12T00:00:00").valueOf();
     var end = new Date("2014-02-13T00:00:00").valueOf();
-    expect(template.totalBasal(start, end)).to.be.closeTo(20.0, EPSILON);
+    expect(template.totalBasal(start, end)).to.equal(20.0);
   });
 
   it('should return 1.45 on basal-template.json from 1 to 3 a.m.', function() {
     var start = new Date("2014-02-12T01:00:00").valueOf();
     var end = new Date("2014-02-12T03:00:00").valueOf();
-    expect(template.totalBasal(start, end)).to.be.closeTo(1.45, EPSILON);
+    expect(template.totalBasal(start, end)).to.equal(1.45);
   });
 
   it('should return 5.35 on basal-contained.json from 8:30 a.m. to 3:30 p.m.', function() {
     var start = new Date("2014-02-12T08:30:00").valueOf();
     var end = new Date("2014-02-12T15:30:00").valueOf();
-    expect(temp.totalBasal(start, end)).to.be.closeTo(5.35, EPSILON);
+    expect(temp.totalBasal(start, end)).to.equal(5.35);
   });
 });
 
@@ -162,11 +160,15 @@ describe('segmentDose', function() {
     assert.isFunction(basal.segmentDose);
   });
 
-  it('should return 1.0', function() {
-    expect(basal.segmentDose(MS_IN_HOUR, 1)).to.be.closeTo(1.0, EPSILON);
+  it('should return 0.0 on a zero rate', function() {
+    expect(basal.segmentDose(MS_IN_HOUR, 0)).to.equal(0.0);
   });
 
-  it('should return 1.2', function() {
-    expect(basal.segmentDose(MS_IN_HOUR * 1.5, 0.8)).to.be.closeTo(1.2, EPSILON);
+  it('should return 1.0 on a rate of 1U for one hour', function() {
+    expect(basal.segmentDose(MS_IN_HOUR, 1)).to.equal(1.0);
+  });
+
+  it('should return 1.2 on a rate of 0.8U for 1.5 hours', function() {
+    expect(basal.segmentDose(MS_IN_HOUR * 1.5, 0.8)).to.equal(1.2);
   });
 });


### PR DESCRIPTION
Opening this for comment: my initial strategy here is to keep the imprecise floating point numbers. I'll use `d3.format()` to keep such things from ever being displayed.

The only issue then is creating tests that will pass even when an expected result such as `1.2` comes out as `1.20000000000002`. To solve this problem, I'm using chai's `.closeTo(value, delta)` with the delta set at `.00001`.

The two obvious alternatives (and reason why I rejected them) are:
- use JavaScript's `toPrecision()` to round the imprecise floating point numbers...problem here is that `toPrecision(3)` will give you `12.3` but `1.23`, so it doesn't control number of decimal places, it controls total digits.
- use the JavaScript port of Java's `BigDecimal` class. Cons here are just that's in an extra dependency and perhaps unnecessary. The port doesn't appear to be in npm or bower, only available [on GitHub](https://github.com/dtrebbien/BigDecimal.js).

Thoughts?
