### PR TITLE
Fix underscore dependency for tests and browserify

### DIFF
--- a/js/lib/underscore.js
+++ b/js/lib/underscore.js
@@ -20,11 +20,6 @@ var _;
 if (typeof window !== 'undefined') {
   _ = window._;
 }
-else {
-  // Required for node tests
-  // Will not get bundled into browserify build because inside an "if" block
-  _ = require('underscore');
-}
 
 if (!_) {
   throw new Error('Underscore or Lodash is a required dependency');

--- a/test/basalutil.js
+++ b/test/basalutil.js
@@ -25,6 +25,11 @@ var _ = require('underscore');
 
 var fx = require('./fixtures');
 
+// Tideline expects a global `window` object to grab its dependencies
+// Not very pretty to add one this way, but as long as we run
+// these tests in Node (vs. in the browser), this is required
+global.window = {_: _};
+
 var BasalUtil = require('../js/data/basalutil');
 
 fx.forEach(testData);


### PR DESCRIPTION
This fixes an issue @cheddar raised when trying to build Blip.

Commit message:

Tideline is a client-side lib that expects a global `window` object (to
grap its dependencies, like underscore).

Tests (for now?) are run in Node (vs. the browser), which means no
global `window` object.

We manually add `global.window` with necessary dependencies before
running the tests.

Note that we can't just use `require('underscore')`, as this will bundle
all of underscore into `tideline.js` (or just produce an error as
underscore isn't installed in `node_modules` when installing Tideline
with Bower).
