### PR TITLE
add test fixture for basal data ending in a temp segment that fails tests

### DIFF
--- a/test/fixtures/basal-temp-final.json
+++ b/test/fixtures/basal-temp-final.json
@@ -1,0 +1,92 @@
+[
+    {
+        "delivered": 0.8,
+        "end": "2014-02-12T02:00:00",
+        "deliveryType": "scheduled",
+        "inferred": false,
+        "value": 0.8,
+        "start": "2014-02-12T00:00:00",
+        "type": "basal-rate-segment",
+        "id": "ae491e22-b122-4d53-98ab-c4c52ab9e7e1"
+    },
+    {
+        "delivered": 0.65,
+        "end": "2014-02-12T04:00:00",
+        "deliveryType": "scheduled",
+        "inferred": false,
+        "value": 0.6500000000000001,
+        "start": "2014-02-12T02:00:00",
+        "type": "basal-rate-segment",
+        "id": "26a07670-4fb7-4dc7-97b4-96a0c549be4e"
+    },
+    {
+        "delivered": 0.75,
+        "end": "2014-02-12T05:00:00",
+        "deliveryType": "scheduled",
+        "inferred": false,
+        "value": 0.7500000000000001,
+        "start": "2014-02-12T04:00:00",
+        "type": "basal-rate-segment",
+        "id": "99e1613c-93ba-4ad2-9cec-ad04f650d6c5"
+    },
+    {
+        "delivered": 0.85,
+        "end": "2014-02-12T06:00:00",
+        "deliveryType": "scheduled",
+        "inferred": false,
+        "value": 0.8500000000000001,
+        "start": "2014-02-12T05:00:00",
+        "type": "basal-rate-segment",
+        "id": "8955a422-9110-4d2d-9bfe-73df2966584b"
+    },
+    {
+        "delivered": 1,
+        "end": "2014-02-12T09:00:00",
+        "deliveryType": "scheduled",
+        "inferred": false,
+        "value": 1,
+        "start": "2014-02-12T06:00:00",
+        "type": "basal-rate-segment",
+        "id": "ca1694c6-79e9-481f-b5c5-a296853d0e29"
+    },
+    {
+        "delivered": 0.8,
+        "end": "2014-02-12T15:00:00",
+        "deliveryType": "scheduled",
+        "inferred": false,
+        "value": 0.8,
+        "start": "2014-02-12T09:00:00",
+        "type": "basal-rate-segment",
+        "id": "d7e6e692-3371-409b-8d7a-e6ee6097b2d1"
+    },
+    {
+        "delivered": 0.9,
+        "end": "2014-02-12T20:00:00",
+        "deliveryType": "scheduled",
+        "inferred": false,
+        "value": 0.9,
+        "start": "2014-02-12T15:00:00",
+        "type": "basal-rate-segment",
+        "id": "66b61050-22e7-4224-8fa5-98a869b9bcf5"
+    },
+    {
+        "delivered": 0.8,
+        "end": "2014-02-13T00:00:00",
+        "deliveryType": "scheduled",
+        "inferred": false,
+        "value": 0.8,
+        "start": "2014-02-12T20:00:00",
+        "type": "basal-rate-segment",
+        "id": "d2fa3a4c-7692-4e65-b65b-b26a0c5341bb"
+    },
+    {
+        "delivered": 0.4,
+        "end": "2014-02-13T00:30:00",
+        "deliveryType": "temp",
+        "inferred": false,
+        "value": 0.4,
+        "start": "2014-02-12T21:00:00",
+        "type": "basal-rate-segment",
+        "id": "d7e6e692-3371-409b-8d7a-e6ee6097b2d1"
+    }
+]

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -25,5 +25,6 @@ fixtures.push({'name': 'two-scheduled', 'json': require('./basal-temp-two-schedu
 fixtures.push({'name': 'many-scheduled', 'json': require('./basal-temp-many-scheduled')});
 fixtures.push({'name': 'both-ends', 'json': require('./basal-temp-both-ends')});
 fixtures.push({'name': 'overlapping', 'json': require('./basal-overlapping')});
+fixtures.push({'name': 'temp-final', 'json': require('./basal-temp-final')});
 fixtures.push({'name': 'current-demo', 'json': require('../../example/device-data')});
 module.exports = fixtures;


### PR DESCRIPTION
Now that's I've taken a closer look at this, I think this might be situation where `demo_data.py` should be modified, not `basalutil.js` because I think this might be a case of data that will not occur in the wild.

The situation is having an array of `'type': 'basal-rate-segment'` objects where the final one is a temp basal that extends beyond the end of any of the `'deliveryType': 'scheduled'` segments. And that, I believe, will not arise in the wild, or should not, if the tools mungeing data from mongo to hand off to the viz do it properly. Assuming we have reliable data about schedules (i.e.,  none of this applies to Animas), basal rate segment data should always start and end with scheduled segments, yes?

We should probably discuss this sometime this week @cheddar and @bewest.
