### PR TITLE
Fix timezone fill issue by scaling 'width' with UTC dates, instead of local dates

### DIFF
--- a/js/plot/util/fill.js
+++ b/js/plot/util/fill.js
@@ -66,10 +66,6 @@ module.exports = function(pool, opts) {
       pushFillFor(range[i], range[i + 1]);
     }
 
-    if (opts.dataGutter) {
-      fills.shift();
-    }
-
     selection.selectAll('rect')
       .data(fills)
       .enter()
@@ -77,7 +73,7 @@ module.exports = function(pool, opts) {
       .attr({
         'x': function(d, i) {
           if (opts.dataGutter) {
-            if (i === fills.length  - 1) {
+            if (i === 0) {
               return d.x - opts.dataGutter;
             }
             else {


### PR DESCRIPTION
# What? Why?

Width calculation was weird around DST, primarily because we were using local dates and plugging them into a `d3.utc` time scale. I'm sure there is a better way to fix this issue, but I'm no pro w/ js dates :(
# How was it tested?

Scrolled to March 8/9 boundary, and saw that there is not white space in the fill color.

Note: this fixes the issue w/ safari, mainly because of the findNearestHourForDate helper function I added.

@jebeck 
