### PR TITLE
better ticks for day axis in two-week view

### DIFF
--- a/js/two-week.js
+++ b/js/two-week.js
@@ -38,7 +38,7 @@ module.exports = function(emitter) {
       scrollThumbRadius: 8,
       currentTranslation: 0
     },
-    axisGutter = 40, dayTickSize = 0,
+    axisGutter = 52, dayTickSize = 0,
     statsHeight = 100,
     pools = [], poolGroup, days, daysGroup,
     xScale = d3.scale.linear(), xAxis, yScale = d3.time.scale.utc(), yAxis,


### PR DESCRIPTION
Three improvements:
- no tick lines
- stacked weekday, month, and date info
- bigger gutters around weekend days

Closes #45, #32, #31.
