### PR TITLE
Ignore examples in bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "authors": [
     "Jana E. Beck <jana.eliz.beck@gmail.com>"
   ],
@@ -12,7 +12,8 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "example"
   ],
   "dependencies": {
     "d3": "~3.4.3",


### PR DESCRIPTION
@jebeck: Now that Blip isn't pulling watson from the `example/` folder, I think we should remove it from the Bower package. Downloading >10MB of sample data on `bower install` isn't great :)

An idea, and this isn't high-priority but I thought of doing it for Blip too, is to put all sample data in a separate repo (say `tideline-sample-data`), and install it via npm. The thing is, your git history for Tideline is getting pretty big with these multi-MB files.. (same goes for Blip's sample data, although it has changed much for now).

@cheddar For client-side packages installed via Bower (so `tideline`, `platform-client` for now), could you remember to update the version in `bower.json` too please? (I did it for this one). Thanks

![screen shot 2014-03-28 at 4 09 45 pm](https://cloud.githubusercontent.com/assets/1306536/2551182/888c139c-b68b-11e3-99ee-7191d14bd843.png)
