### PR TITLE
Round when formatting percentages, instead of truncating. Fixes #65.

### DIFF
--- a/js/data/util/format.js
+++ b/js/data/util/format.js
@@ -9,7 +9,7 @@ var format = {
       return '-- %';
     }
     else {
-      return parseInt(f.toFixed(2) * 100, 10) + '%';
+      return parseInt(Math.round(f * 100), 10) + '%';
     }
   }
 


### PR DESCRIPTION
Didn't write up a test for this.. Testing pretty much consisted of me moving the scroll-bar back and forth in the one-day view. I saw the percentages not equaling 100% before the fix. Afterward, I did not. Let me know if you want some more formal testing.
