### PR TITLE
Watson adjusts a message-api utcTime by the current brower time offset

### DIFF
--- a/plugins/data/watson/index.js
+++ b/plugins/data/watson/index.js
@@ -86,6 +86,7 @@ module.exports = {
       var offsetMinutes = d.getTimezoneOffset();
       d.setUTCMinutes(d.getUTCMinutes() - offsetMinutes);
       i.utcTime = d.toISOString();
+      return i;
     }
     catch(e) {
       throw new TypeError('Watson choked on an undefined.');


### PR DESCRIPTION
Needs to be in concert with blip's PR of the same branch name.
