### PR TITLE
Standardize on past tense

### DIFF
--- a/plugins/data/preprocess/index.js
+++ b/plugins/data/preprocess/index.js
@@ -49,7 +49,8 @@ function processSuspends(data) {
         case 'suspended':
           suspends[data[i].id] = data[i];
           break;
-        case 'resume':
+        case 'resumed':
+        case 'resume': // 2014-05-06: Non past-tense should be removed.  If this still exists in June, please remove
           if (data[i].joinKey == null) {
             retVal.push(data[i]);
           } else {


### PR DESCRIPTION
For status events, I'd like to standardize on past tense.  This is a change to allow tideline to handle both for now.

@jebeck have a look and merge when ready, pls
