### PR TITLE
fix two-week view bug

### DIFF
--- a/plugins/blip/chartweeklyfactory.js
+++ b/plugins/blip/chartweeklyfactory.js
@@ -75,7 +75,7 @@ function chartWeeklyFactory(el, options) {
     }
     else {
       if (smbgData.length &&
-          datetime.valueOf() > Date.parse(smbgData[smbgData.length - 1].normalTime)) {
+          Date.parse(datetime) > Date.parse(smbgData[smbgData.length - 1].normalTime)) {
         datetime = smbgData[smbgData.length - 1].normalTime;
       }
       chart.data(smbgData, datetime);


### PR DESCRIPTION
@brandonarbiter This was an easier fix than I thought \o/

What I've done (or rather, what the logic I'd already written had done, if there hadn't been a silly bug) is that two-week view will always only contain the date range that's available for smbgs, since that's all that it shows (for now - will be easy to update if we add more data types to two-week view). So now if you click on two weeks from one-day view where all you have is a blank and one recent note, you'll be taken to your most recent smbg data in two-week view, which could be a long time ago if you've been using notes but haven't uploaded data in a month, say.

It would be fairly trivial to change this so that we're generating blank pools when there's no recent smbg data in two-week view, so let's talk about what everyone prefers, although I'd prefer to get this bug fix in as fast as possible, since it is a somewhat terrible bug.
