### PR TITLE
provide panForward and panBack functions to prevent TypeError

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -304,5 +304,15 @@ module.exports = function(emitter, opts) {
     return container;
   };
 
+  container.panForward = function() {
+    // TODO: fill in when we support navigation of settings
+    // defined for now to prevent TypeError
+  };
+
+  container.panBack = function() {
+    // TODO: fill in when we support navigation of settings
+    // defined for now to prevent TypeError
+  };
+
   return container;
 };


### PR DESCRIPTION
The settings page did not have panForward and panBack functions defined (yet) since we don't yet support navigation through settings history.
