### PR TITLE
update conversion constant for mmol/L data

### DIFF
--- a/plugins/data/preprocess/index.js
+++ b/plugins/data/preprocess/index.js
@@ -115,7 +115,7 @@ var Preprocess = {
 
   MGDL_STRING: 'mg/dL',
 
-  MMOL_TO_MGDL: 18,
+  MMOL_TO_MGDL: 18.01559,
 
   mungeBasals: function(data) {
     var segments = new SegmentUtil(data);

--- a/test/preprocess_test.js
+++ b/test/preprocess_test.js
@@ -64,8 +64,8 @@ describe('Preprocess', function() {
   });
 
   describe('MMOL_TO_MGDL', function() {
-    it('should be 18', function() {
-      expect(Preprocess.MMOL_TO_MGDL).to.equal(18);
+    it('should be 18.01559', function() {
+      expect(Preprocess.MMOL_TO_MGDL).to.equal(18.01559);
     });
   });
 


### PR DESCRIPTION
Per the conversation around the data model, I updated the constant for tideline's current conversion from mmol/L data (for enabling Sara to dogfood). @cheddar or @kentquirk sign off on it?
