### PR TITLE
flip settings norgie for basal schedules to match tabular basal settings norgie in one-day view

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -235,7 +235,7 @@ module.exports = function(emitter, opts) {
             return 'd3-settings-col-label d3-settings-col-collapsed';
           }
         })
-        .html((scheduleClass ? '<i class="icon-up"></i>' : '<i class="icon-down"></i>') + datatype);
+        .html((scheduleClass ? '<i class="icon-down"></i>' : '<i class="icon-up"></i>') + datatype);
     }
 
     var columnTable = columnDiv.append('table');
@@ -272,8 +272,8 @@ module.exports = function(emitter, opts) {
         var current = d3.select(this).classed('d3-settings-col-active');
         
         d3.select(this).selectAll('i').classed({
-          'icon-up': !current,
-          'icon-down': current
+          'icon-down': !current,
+          'icon-up': current
         });
 
         d3.select(this).classed({
@@ -295,26 +295,6 @@ module.exports = function(emitter, opts) {
     mainDiv.remove();
 
     return container;
-  };
-
-  container.hide = function() {
-    // for API identity with oneday
-    return container;
-  };
-
-  container.show = function() {
-    // for API identity with oneday
-    return container;
-  };
-
-  container.panForward = function() {
-    // TODO: fill in when we support navigation of settings
-    // defined for now to prevent TypeError
-  };
-
-  container.panBack = function() {
-    // TODO: fill in when we support navigation of settings
-    // defined for now to prevent TypeError
   };
 
   return container;


### PR DESCRIPTION
This is what we want (temporarily, until new icon font), right? Up is closed, down is open:

In one-day view:
![screenshot 2014-07-10 19 53 51](https://cloud.githubusercontent.com/assets/1588547/3548102/9dc0d5be-08a6-11e4-83c0-438f11ec17af.png)
![screenshot 2014-07-10 19 54 24](https://cloud.githubusercontent.com/assets/1588547/3548107/afc96280-08a6-11e4-9e7f-dc08e3536d33.png)

In settings view:
![screenshot 2014-07-10 19 51 35](https://cloud.githubusercontent.com/assets/1588547/3548098/84c63810-08a6-11e4-97fc-edc83d2bdb7c.png)
![screenshot 2014-07-10 19 51 45](https://cloud.githubusercontent.com/assets/1588547/3548099/879e8128-08a6-11e4-94dd-821d3daf2657.png)

@ianjorgensen want to review if you don't have the new icon font plus changes to use it ready today?
