### PR TITLE
only call tidelineData.editDatum if edited message is a top-level note

### DIFF
--- a/plugins/blip/chartdailyfactory.js
+++ b/plugins/blip/chartdailyfactory.js
@@ -421,7 +421,7 @@ function chartDailyFactory(el, options) {
     log('Message timestamp edited:', message);
     // tideline only cares if the edited message was a top-level note
     // not a comment
-    if (message.parentMessage === '') {
+    if (_.isEmpty(message.parentMessage)) {
       chart.tidelineData.editDatum(message, 'utcTime');
       chart.data(chart.tidelineData);
       chart.emitter.emit('messageTimestampEdited', message);


### PR DESCRIPTION
This should fix bug reported here: https://trello.com/c/4OyJ9ryd where user gets an error when editing the text of a comment (not a top-level note) in blip.

@jh-bate review at your leisure :)
