### PR TITLE
have a proper fall-through if no timezone offset available

### DIFF
--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -388,6 +388,10 @@ function TidelineData(data, opts) {
             d.normalTime = datumDt.toISOString();
             d.displayOffset = 0;
           }
+          else {
+            d.normalTime = d.time;
+            d.displayOffset = 0;
+          }
           if (d.deviceTime && d.normalTime.slice(0, -5) !== d.deviceTime) {
             d.warning = 'Combining `time` and `timezoneOffset` does not yield `deviceTime`.';
           }

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -388,6 +388,7 @@ function TidelineData(data, opts) {
             d.normalTime = datumDt.toISOString();
             d.displayOffset = 0;
           }
+          // timezoneOffset is an optional attribute according to the Tidepool data model
           else {
             d.normalTime = d.time;
             d.displayOffset = 0;


### PR DESCRIPTION
Small fix for an issue @cheddar pointed out: our data model docs explicitly say `timezoneOffset` is an optional attribute, but tideline was expecting it to always be there.

@jh-bate would you mind doing a very quick little review?