### PR TITLE
wrap annotation creation in an outer if for when annotations embedded

### DIFF
--- a/js/plot/util/annotations/annotation.js
+++ b/js/plot/util/annotations/annotation.js
@@ -48,44 +48,46 @@ module.exports = function(container, annotationsGroup) {
 
     var hoverTarget;
 
-    if (opts.d.annotations[0].code.slice(0, 6) === 'stats-') {
-      // NB: this (temporarily) disables the new explainer tooltips
-      // for all stats widget components when stats are active
-      if (opts.d.annotations[0].code !== 'stats-insufficient-data') {
-        return;
+    if (opts && opts.d && opts.d.annotations && opts.d.annotations.length > 0) {
+      if (opts.d.annotations[0].code.slice(0, 6) === 'stats-') {
+        // NB: this (temporarily) disables the new explainer tooltips
+        // for all stats widget components when stats are active
+        if (opts.d.annotations[0].code !== 'stats-insufficient-data') {
+          return;
+        }
+        if (opts.hoverTarget != null) {
+          hoverTarget = opts.hoverTarget;
+        }
+        annotation.tooltip(opts, selection, hoverTarget);
       }
-      if (opts.hoverTarget != null) {
-        hoverTarget = opts.hoverTarget;
+      else {
+        var iconGroup = selection.append('g')
+          .attr('class', 'd3-data-annotation-group')
+          .attr('id', 'annotation_for_' + opts.d.id);
+
+        opts.x = annotation.xOffset(opts);
+        opts.y = annotation.yOffset(opts);
+
+        hoverTarget = iconGroup.append('circle')
+          .attr({
+            'cx': opts.x,
+            'cy': opts.y,
+            'r': r,
+            'class': 'd3-circle-data-annotation',
+          });
+        iconGroup.append('text')
+          .attr({
+            'x': opts.x,
+            'y': opts.y,
+            'class': 'd3-text-data-annotation'
+          })
+          .text('?');
+
+        if (opts.hoverTarget != null) {
+          hoverTarget = opts.hoverTarget;
+        }
+        annotation.tooltip(opts, selection, hoverTarget);
       }
-      annotation.tooltip(opts, selection, hoverTarget);
-    }
-    else {
-      var iconGroup = selection.append('g')
-        .attr('class', 'd3-data-annotation-group')
-        .attr('id', 'annotation_for_' + opts.d.id);
-
-      opts.x = annotation.xOffset(opts);
-      opts.y = annotation.yOffset(opts);
-
-      hoverTarget = iconGroup.append('circle')
-        .attr({
-          'cx': opts.x,
-          'cy': opts.y,
-          'r': r,
-          'class': 'd3-circle-data-annotation',
-        });
-      iconGroup.append('text')
-        .attr({
-          'x': opts.x,
-          'y': opts.y,
-          'class': 'd3-text-data-annotation'
-        })
-        .text('?');
-
-      if (opts.hoverTarget != null) {
-        hoverTarget = opts.hoverTarget;
-      }
-      annotation.tooltip(opts, selection, hoverTarget);
     }
   }
 

--- a/js/plot/util/annotations/annotation.js
+++ b/js/plot/util/annotations/annotation.js
@@ -48,7 +48,7 @@ module.exports = function(container, annotationsGroup) {
 
     var hoverTarget;
 
-    if (opts && opts.d && opts.d.annotations && opts.d.annotations.length > 0) {
+    if (opts && opts.d && !_.isEmpty(opts.d.annotations)) {
       if (opts.d.annotations[0].code.slice(0, 6) === 'stats-') {
         // NB: this (temporarily) disables the new explainer tooltips
         // for all stats widget components when stats are active


### PR DESCRIPTION
This is the fix for the crashing-while-scrolling error in current blip. The issue is with certain annotations. Annotations are expected to always be at the top level of a datum, but sometimes (on wizard events) they are embedded inside a bolus and unfindable. This code is a short term solution to make sure tideline doesn't throw a JS error when it can't find the annotation at the top level; it has the side effect that the annotation in question won't be displayed.

The long term solution will be amending nurse shark to move bolus annotations to the top level of a wizard object, but since there may be the possibility of annotations existing in both places, that code will be more than a couple lines, and I want to get this fix out first, which won't do any harm in the long run.

@jh-bate review plz.