### PR TITLE
as first step in nurseshark's processData, remove any data without `time` field

### DIFF
--- a/plugins/nurseshark/index.js
+++ b/plugins/nurseshark/index.js
@@ -181,10 +181,7 @@ var nurseshark = {
     function removeNoTime() {
       var noTimeCount = 0;
       data = _.filter(data, function(d) {
-        if (d.type !== 'message' && d.time != null) {
-          return true;
-        }
-        else if (d.type === 'message') {
+        if (d.timestamp != null || d.time != null) {
           return true;
         }
         else {
@@ -192,7 +189,7 @@ var nurseshark = {
           return false;
         }
       });
-      log(noTimeCount, 'records removed due to not having a `time` field.');
+      log(noTimeCount, 'records removed due to not having a `time` or `timestamp` field.');
     }
     timeIt(removeNoTime, 'removeNoTime');
 
@@ -327,18 +324,12 @@ var nurseshark = {
     var lastD, unannotatedRemoval = false;
 
     function process(d) {
-      // NB: to avoid tideline crashing on legacy old data model data
-      if (!(d.time || d.timestamp)) {
-        d.errorMessage = 'No time or timestamp field; suspected legacy old data model data.';
+      if (overlappingUploads[d.deviceId] && d.deviceId !== mostRecentFromOverlapping) {
+        d = cloneDeep(d);
+        d.errorMessage = 'Overlapping CareLink upload.';
       }
       else {
-        if (overlappingUploads[d.deviceId] && d.deviceId !== mostRecentFromOverlapping) {
-          d = cloneDeep(d);
-          d.errorMessage = 'Overlapping CareLink upload.';
-        }
-        else {
-          d = handlers[d.type] ? handlers[d.type](d, collections) : d.messagetext ? handlers.message(d, collections) : addNoHandlerMessage(d);
-        }
+        d = handlers[d.type] ? handlers[d.type](d, collections) : d.messagetext ? handlers.message(d, collections) : addNoHandlerMessage(d);
       }
 
       // because we don't yet have validation on editing timestamps in clamshell and blip notes

--- a/plugins/nurseshark/index.js
+++ b/plugins/nurseshark/index.js
@@ -181,7 +181,10 @@ var nurseshark = {
     function removeNoTime() {
       var noTimeCount = 0;
       data = _.filter(data, function(d) {
-        if (d.time != null) {
+        if (d.type !== 'message' && d.time != null) {
+          return true;
+        }
+        else if (d.type === 'message') {
           return true;
         }
         else {

--- a/plugins/nurseshark/index.js
+++ b/plugins/nurseshark/index.js
@@ -177,6 +177,22 @@ var nurseshark = {
     if (!(data && data.length >= 0 && Array.isArray(data))) {
       throw new Error('An array is required.');
     }
+    // data from the old-old data model (pre-v1 docs) doesn't have a `time` field
+    function removeNoTime() {
+      var noTimeCount = 0;
+      data = _.filter(data, function(d) {
+        if (d.time != null) {
+          return true;
+        }
+        else {
+          noTimeCount += 1;
+          return false;
+        }
+      });
+      log(noTimeCount, 'records removed due to not having a `time` field.');
+    }
+    timeIt(removeNoTime, 'removeNoTime');
+
     var processedData = [], erroredData = [];
     var collections = {
       allBoluses: {},

--- a/test/nurseshark_test.js
+++ b/test/nurseshark_test.js
@@ -45,15 +45,6 @@ describe('nurseshark', function() {
       expect(res.processedData.length).to.equal(0);
     });
 
-    it('should exclude suspected legacy old data model data in the erroredData', function() {
-      var data = [{
-        type: 'message'
-      }];
-      var res = nurseshark.processData(data);
-      expect(res.erroredData.length).to.equal(1);
-      expect(res.erroredData[0].errorMessage).to.equal('No time or timestamp field; suspected legacy old data model data.');
-    });
-
     describe('on overlapping Carelink uploads', function() {
       var now = new Date();
       var plusTen = new Date(now.valueOf() + 600000);

--- a/test/nurseshark_test.js
+++ b/test/nurseshark_test.js
@@ -36,9 +36,18 @@ describe('nurseshark', function() {
       expect(fn).to.throw('An array is required.');
     });
 
-    it('should include suspected legacy old data model data in the erroredData', function() {
+    it('should exclude pre-v1 data model data', function() {
       var data = [{
         deviceTime: ''
+      }];
+      var res = nurseshark.processData(data);
+      expect(res.erroredData.length).to.equal(0);
+      expect(res.processedData.length).to.equal(0);
+    });
+
+    it('should exclude suspected legacy old data model data in the erroredData', function() {
+      var data = [{
+        type: 'message'
       }];
       var res = nurseshark.processData(data);
       expect(res.erroredData.length).to.equal(1);
@@ -361,7 +370,7 @@ describe('nurseshark', function() {
     });
 
     it('should log an error when no type handler exists for an obj in the input array', function() {
-      var res = nurseshark.processData([{type:'foo'}]);
+      var res = nurseshark.processData([{type:'foo', time: '2014-01-01T00:00:00.000Z'}]);
       expect(res.erroredData.length).to.equal(1);
     });
 
@@ -549,6 +558,7 @@ describe('nurseshark', function() {
         timezoneOffset: 0
       }, {
         type: 'deviceMeta',
+        time: new Date().toISOString(),
         annotations: [{
           code: 'status/unknown-previous'
         }],


### PR DESCRIPTION
Only has a ~4ms impact on nurseshark's processing time even when removing 40,000+ records, so I'm happy with it.

@jh-bate quick review.