### PR TITLE
two-tone color scheme for trends view days of the week

### DIFF
--- a/css/tideline-colors.less
+++ b/css/tideline-colors.less
@@ -79,13 +79,16 @@
 // tooltips
 @title-background: #EAEAEE;
 
-// modal day
-@monday: #B7E66E;
-@tuesday: #5ACA64;
-@wednesday: #37BFB9;
-@thursday: #1EA2DC;
-@friday: #4E8ADB;
-@saturday: #E5E200;
-@sunday: #E5B20C;
+@weekday: #3D9998;
+@weekend: #5DE8DE;
 
-@range: #020024;
+// modal day
+@monday: @weekday;
+@tuesday: @weekday;
+@wednesday: @weekday;
+@thursday: @weekday;
+@friday: @weekday;
+@saturday: @weekend;
+@sunday: @weekend;
+
+@range: #116152;


### PR DESCRIPTION
What it says on the tin. This should be merged and tagged before [the corresponding blip PR](https://github.com/tidepool-org/blip/pull/185) (and the blip PR should be updated with the new tideline version).