### PR TITLE
add carelink/bolus/missing-square-component annotation text

### DIFF
--- a/js/plot/util/annotations/annotationdefinitions.js
+++ b/js/plot/util/annotations/annotationdefinitions.js
@@ -44,6 +44,11 @@ var definitions = {
       var b = " reports the data, we can't be 100% certain of your basal rate here.";
       return defs.stitch(a, b, source);
     },
+    'carelink/bolus/missing-square-component': function(source, defs) {
+      var a = "Because of how ";
+      var b = " reports bolus and wizard data, we may have failed to combine a square-wave bolus with this normal bolus to display a dual-wave bolus.";
+      return defs.stitch(a, b, source);
+    },
     'carelink/wizard/long-search': function(source, defs) {
       var a = "Because of how ";
       var b = " reports bolus and wizard data, we can't be 100% certain that the bolus wizard information here (e.g., carbs, suggested dose) corresponds with the bolus.";

--- a/js/plot/util/annotations/annotationdefinitions.js
+++ b/js/plot/util/annotations/annotationdefinitions.js
@@ -46,7 +46,7 @@ var definitions = {
     },
     'carelink/bolus/missing-square-component': function(source, defs) {
       var a = "Because of how ";
-      var b = " reports bolus and wizard data, this normal and square-wave bolus may not be properly combined to appear as a dual-wave bolus.";
+      var b = " reports bolus data, normal and square-wave boluses may not be properly combined to appear as a dual-wave bolus.";
       return defs.stitch(a, b, source);
     },
     'carelink/wizard/long-search': function(source, defs) {

--- a/js/plot/util/annotations/annotationdefinitions.js
+++ b/js/plot/util/annotations/annotationdefinitions.js
@@ -46,7 +46,7 @@ var definitions = {
     },
     'carelink/bolus/missing-square-component': function(source, defs) {
       var a = "Because of how ";
-      var b = " reports bolus and wizard data, we may have failed to combine a square-wave bolus with this normal bolus to display a dual-wave bolus.";
+      var b = " reports bolus and wizard data, this normal and square-wave bolus may not be properly combined to appear as a dual-wave bolus.";
       return defs.stitch(a, b, source);
     },
     'carelink/wizard/long-search': function(source, defs) {


### PR DESCRIPTION
Add annotation text for `carelink/bolus/missing-square-component`.

Text is: "Because of how CareLink reports bolus and wizard data, we may have failed to combine a square-wave bolus with this normal bolus to display a dual-wave bolus."

Ping @HowardLook @brandonarbiter 