### PR TITLE
handle upload metadata

### DIFF
--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -490,7 +490,15 @@ function TidelineData(data, opts) {
   });
   
   if (data.length > 0 && !_.isEmpty(this.diabetesData)) {
-    this.data = data;
+    var dData = this.diabetesData;
+    this.data = _.reject(data, function(d) {
+      if (d.type === 'message' && d.normalTime < dData[0].normalTime) {
+        return true;
+      }
+      if (d.type === 'upload') {
+        return true;
+      }
+    });
     this.generateFillData().adjustFillsForTwoWeekView();
     this.data = _.sortBy(this.data.concat(this.grouped.fill), function(d) { return d.normalTime; });
   }

--- a/js/validation/upload.js
+++ b/js/validation/upload.js
@@ -20,7 +20,6 @@ var schema = require('./validator/schematron.js');
 module.exports = schema(
   {
     id: schema().isId(),
-    uploadId: schema().isId(),
     timezone: schema().string(),
     type: schema().string().in(['upload'])
   }

--- a/js/validation/upload.js
+++ b/js/validation/upload.js
@@ -1,0 +1,27 @@
+/* 
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2014, Tidepool Project
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ * 
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+var schema = require('./validator/schematron.js');
+
+module.exports = schema(
+  {
+    id: schema().isId(),
+    uploadId: schema().isId(),
+    timezone: schema().string(),
+    type: schema().string().in(['upload'])
+  }
+);

--- a/js/validation/validate.js
+++ b/js/validation/validate.js
@@ -29,6 +29,7 @@ var schemas = {
   message: require('./message'),
   settings: require('./settings'),
   smbg: require('./bg'),
+  upload: require('./upload'),
   wizard: require('./wizard')
 };
 

--- a/js/validation/validator/schematron.js
+++ b/js/validation/validator/schematron.js
@@ -43,7 +43,7 @@ function typeOf(match) {
   };
 }
 
-var isAnId = matchesRegex(/^[A-Za-z0-9\-\_\=\+\/]+$/);
+var isAnId = matchesRegex(/^[A-Za-z0-9\-\_]+$/);
 // localDate is a date in YYYY-MM-DD format
 var isADate = matchesRegex(/^(\d{4}-[01]\d-[0-3]\d)$/);
 // deviceTime is the raw, non-timezone-aware string

--- a/js/validation/validator/schematron.js
+++ b/js/validation/validator/schematron.js
@@ -43,7 +43,7 @@ function typeOf(match) {
   };
 }
 
-var isAnId = matchesRegex(/^[A-Za-z0-9\-\_]+$/);
+var isAnId = matchesRegex(/^[A-Za-z0-9\-\_\=\+\/]+$/);
 // localDate is a date in YYYY-MM-DD format
 var isADate = matchesRegex(/^(\d{4}-[01]\d-[0-3]\d)$/);
 // deviceTime is the raw, non-timezone-aware string

--- a/plugins/nurseshark/index.js
+++ b/plugins/nurseshark/index.js
@@ -416,7 +416,7 @@ function getHandlers() {
       // NB: truthiness warranted here
       // basals with duration of 0 are *not* legitimate targets for visualization
       if (!d.duration) {
-        var err2 = new Error('Null duration. Expect an `off-schedule-rate` annotation here. Investigate if that is missing.');
+        var err2 = new Error('Basal with null/zero duration.');
         d.errorMessage = err2.message;
         return d;
       }
@@ -511,6 +511,10 @@ function getHandlers() {
       if (d.suppressed.suppressed) {
         this.suppressed(d.suppressed);
       }
+    },
+    upload: function(d) {
+      d = cloneDeep(d);
+      return d;
     },
     wizard: function(d, collections) {
       d = cloneDeep(d);

--- a/test/local/local_tests.js
+++ b/test/local/local_tests.js
@@ -41,7 +41,7 @@ describe('local-only tests', function() {
           else if (error.errorMessage === 'Overlapping CareLink upload.') {
             ok += 1;
           }
-          else if (error.errorMessage === 'Null duration. Expect an `off-schedule-rate` annotation here. Investigate if that is missing.') {
+          else if (error.errorMessage === 'Basal with null/zero duration.') {
             ok += 1;
           }
         }

--- a/test/nurseshark_test.js
+++ b/test/nurseshark_test.js
@@ -427,7 +427,7 @@ describe('nurseshark', function() {
       }];
       var res = nurseshark.processData(nullDuration).erroredData;
       expect(res.length).to.equal(1);
-      expect(res[0].errorMessage).to.equal('Null duration. Expect an `off-schedule-rate` annotation here. Investigate if that is missing.');
+      expect(res[0].errorMessage).to.equal('Basal with null/zero duration.');
     });
 
     it('should extend the duration of Carelink temps and suspends that are one second short', function() {

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -136,7 +136,7 @@ describe('TidelineData', function() {
       expect(toAdd.grouped.bolus.length - 1).to.equal(bolusLen);
     });
 
-    it('should expand the fill data if necessary', function() {
+    it('should expand the fill data on the right if necessary', function() {
       var origData = [new types.Bolus()];
       var toAdd = new TidelineData(origData);
       var origFill = toAdd.grouped.fill;
@@ -373,7 +373,7 @@ describe('TidelineData', function() {
     });
 
     it('should apply the timezone offset of the environment (browser) to a message time when not timezoneAware', function() {
-      var data = [new types.Message(), new types.SMBG()];
+      var data = [new types.SMBG({deviceTime: '2014-01-01T00:00:00'}), new types.Message()];
       var thisTd = new TidelineData(data);
       var datum = _.findWhere(thisTd.data, {type: 'message'});
       var now = new Date();


### PR DESCRIPTION
Changes to handle the new upload metadata object in both nurseshark and validation because the constant error messages in the console were getting annoying/distracting when trying to debug other stuff. (We only validate timezone, basically, because that's what tideline expects to use this for.)

This was also a forcing function for https://trello.com/c/IPEViPMr, so those changes are in the second commit.