### PR TITLE
Removes ordinals from date formats.

### DIFF
--- a/example/components/daily.js
+++ b/example/components/daily.js
@@ -1,16 +1,16 @@
 /** @jsx React.DOM */
-/* 
+/*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -90,9 +90,9 @@ var Daily = React.createClass({
   },
   getTitle: function(datetime) {
     if (this.props.chartPrefs.timePrefs.timezoneAware) {
-      return moment(datetime).tz(this.props.chartPrefs.timePrefs.timezoneName).format('dddd, MMMM Do');
+      return moment(datetime).tz(this.props.chartPrefs.timePrefs.timezoneName).format('dddd, MMMM D');
     }
-    return moment(datetime).utc().format('dddd, MMMM Do');
+    return moment(datetime).utc().format('dddd, MMMM D');
   },
   // handlers
   handleClickModal: function() {

--- a/example/components/modal.js
+++ b/example/components/modal.js
@@ -1,16 +1,16 @@
 /** @jsx React.DOM */
-/* 
+/*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -119,7 +119,7 @@ var Modal = React.createClass({
     else {
       timezone = timePrefs.timezoneName || 'UTC';
     }
-    return moment.utc(datetime).tz(timezone).format('MMMM Do');
+    return moment.utc(datetime).tz(timezone).format('MMMM D');
   },
   getTitle: function(datetimeLocationEndpoints) {
     // endpoint is exclusive, so need to subtract a day

--- a/example/components/weekly.js
+++ b/example/components/weekly.js
@@ -1,16 +1,16 @@
 /** @jsx React.DOM */
-/* 
+/*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -98,7 +98,7 @@ var Weekly = React.createClass({
     /* jshint ignore:end */
   },
   formatDate: function(datetime) {
-    return moment(datetime).utc().format('MMMM Do');
+    return moment(datetime).utc().format('MMMM D');
   },
   getTitle: function(datetimeLocationEndpoints) {
     return this.formatDate(datetimeLocationEndpoints[0]) + ' - ' + this.formatDate(datetimeLocationEndpoints[1]);

--- a/js/data/util/format.js
+++ b/js/data/util/format.js
@@ -1,15 +1,15 @@
 /*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -54,7 +54,7 @@ var format = {
     if (offset) {
       d.setUTCMinutes(d.getUTCMinutes() + offset);
     }
-    return moment.utc(d).format('ddd, MMM Do');
+    return moment.utc(d).format('ddd, MMM D');
   },
 
   fixFloatingPoint: function(n) {
@@ -135,7 +135,7 @@ var format = {
       i = new Date(i);
       i.setUTCMinutes(i.getUTCMinutes() + offset);
     }
-    return moment(i).utc().format('dddd, MMMM Do');
+    return moment(i).utc().format('dddd, MMMM D');
   },
 
   xAxisTickText: function(i, offset) {

--- a/plugins/blip/modalday/ModalDay.js
+++ b/plugins/blip/modalday/ModalDay.js
@@ -259,18 +259,18 @@ d3.chart('ModalDay', {
                     y: labelMargins.y,
                     'class': 'smbgDayLabel'
                   })
-                  .text(moment(d).tz(timezone).format('dddd, MMMM Do'));
+                  .text(moment(d).tz(timezone).format('dddd, MMMM D'));
                 infoPlot = smbgInfo.create(this, {
                   x: chart.xScale(), y: chart.yScale()
                 }, {
                   timezone: chart.timezone()
                 });
-                infoPlot.render(chart.data[d]); 
+                infoPlot.render(chart.data[d]);
               }
               var copy = d3.select(this)[0][0];
               d3.select(this).remove();
               var first = document.getElementById('modalHighlightGroup').firstChild;
-              document.getElementById('modalHighlightGroup').insertBefore(copy, first);  
+              document.getElementById('modalHighlightGroup').insertBefore(copy, first);
             })
             .on('mouseout', function(d) {
               d3.select(this).classed('highlight', false);

--- a/test/format_test.js
+++ b/test/format_test.js
@@ -1,15 +1,15 @@
 /*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -84,15 +84,15 @@ describe('format utility', function() {
       assert.isFunction(fmt.dayAndDate);
     });
 
-    it('should return `Mon, Nov 17th` on a UTC timestamp of midnight 11/17/2014', function() {
+    it('should return `Mon, Nov 17` on a UTC timestamp of midnight 11/17/2014', function() {
       var tstr = '2014-11-17T00:00:00.000Z';
-      expect(fmt.dayAndDate(tstr)).to.equal('Mon, Nov 17th');
+      expect(fmt.dayAndDate(tstr)).to.equal('Mon, Nov 17');
     });
 
-    it('should return `Mon, Nov 17th` on a UTC timestamp of 8 a.m. 11/17/2014 when passed a Pacific DST offset', function() {
+    it('should return `Mon, Nov 17` on a UTC timestamp of 8 a.m. 11/17/2014 when passed a Pacific DST offset', function() {
       var tstr = '2014-11-17T08:00:00.000Z';
-      expect(fmt.dayAndDate(new Date(Date.parse(tstr) - 1).toISOString(), -480)).to.equal('Sun, Nov 16th');
-      expect(fmt.dayAndDate(tstr, -480)).to.equal('Mon, Nov 17th');
+      expect(fmt.dayAndDate(new Date(Date.parse(tstr) - 1).toISOString(), -480)).to.equal('Sun, Nov 16');
+      expect(fmt.dayAndDate(tstr, -480)).to.equal('Mon, Nov 17');
     });
   });
 
@@ -168,12 +168,12 @@ describe('format utility', function() {
       assert.isFunction(fmt.xAxisDayText);
     });
 
-    it('should return `Wednesday, January 1st` on a UTC timestamp at 1 am on first day of 2014', function() {
-      expect(fmt.xAxisDayText('2014-01-01T01:00:00.000Z')).to.equal('Wednesday, January 1st');
+    it('should return `Wednesday, January 1` on a UTC timestamp at 1 am on first day of 2014', function() {
+      expect(fmt.xAxisDayText('2014-01-01T01:00:00.000Z')).to.equal('Wednesday, January 1');
     });
 
-    it('should return `Tuesday, December 31st` on same UTC timestamp when passed a Pacific non-DST offset', function() {
-      expect(fmt.xAxisDayText('2014-01-01T01:00:00.000Z', -480)).to.equal('Tuesday, December 31st');
+    it('should return `Tuesday, December 31` on same UTC timestamp when passed a Pacific non-DST offset', function() {
+      expect(fmt.xAxisDayText('2014-01-01T01:00:00.000Z', -480)).to.equal('Tuesday, December 31');
     });
   });
 


### PR DESCRIPTION
@jebeck 

This PR removes ordinals from date formats in tideline. There were a couple of component files to update in examples, but the main update was in the format.js utils file. I found ordinals in the tooltip hover from the trends chart as well as the date in the top left corner of the Daily view, so those have been corrected. I think this should cover it, but let me know what you think. 

Resolves: https://trello.com/c/N17FVhV4