### PR TITLE
add coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ example/data/blip-output.json
 tmp/
 web/
 wiki/
+
+# istanbul output
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-   - "0.10"
-
+  - "0.10"
 script:
-- "npm run jshint"
-- "npm run travis"
+  - "npm run jshint"
+  - "npm run travis"
+after_script: "npm install coveralls && cat ./coverage/lcov.info | coveralls"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 tideline
 ========
 
-[![Build Status](https://travis-ci.org/tidepool-org/tideline.png?branch=master)](https://travis-ci.org/tidepool-org/tideline)
+[![Build Status](https://img.shields.io/travis/tidepool-org/tideline/master.svg)](https://travis-ci.org/tidepool-org/tideline)
+[![Coverage Status](https://img.shields.io/coveralls/tidepool-org/tideline/master.svg)](https://coveralls.io/r/tidepool-org/tideline)
 
 This repository is a self-contained module library for [Tidepool](http://tidepool.org/ 'Tidepool')'s timeline-style diabetes data visualization(s).
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "js/index.js",
   "scripts": {
-    "travis": "./node_modules/.bin/mocha test/*_test.js",
+    "travis": "istanbul cover node_modules/mocha/bin/_mocha test/*_test.js",
     "test": "testem",
     "start": "BUILD_DEV=true webpack-dev-server -d --cache --colors --progress --content-base example --port 8081",
     "build-test": "webpack --config test.config.js",
@@ -36,6 +36,7 @@
     "file-loader": "0.5.1",
     "gulp": "3.8.7",
     "gulp-jshint": "1.8.4",
+    "istanbul": "0.3.5",
     "jquery": "2.1.1",
     "jquery-simulate": "git://github.com/jquery/jquery-simulate.git#b91832e9f1f65ee6c6f2dc93a5e917735c33db8e",
     "jshint": "2.5.5",


### PR DESCRIPTION
This contribution is based on an email conversation with @brandonarbiter and @jebeck. A Tideline admin will need to enable the repo at coveralls.io before the coverage info will appear on the README badge, but a working example using my own fork looks like [this](https://github.com/dduugg/tideline/tree/example).

I agree to the terms of Tidepool Project’s Contributor License Agreement as it exists at http://tidepool-org.github.io/TidepoolCLA.pdf on 2015-01-31