### PR TITLE
adjust to display Insulet-style bgTarget settings

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -91,6 +91,15 @@ module.exports = function(opts) {
     if (!arguments.length) return settings;
 
     settings = data.grouped.settings;
+    var firstBgTarget = settings[settings.length - 1].bgTarget[0];
+    if (_.has(firstBgTarget, 'target') && _.has(firstBgTarget, 'high')) {
+      opts.rowHeadersByType.bgTarget = ['Start time', 'Target (' + opts.bgUnits + ')', 'High (' + opts.bgUnits + ')'];
+      opts.mapsByType.bgTarget = {
+        start: msStartString,
+        target: function(x) { return x; },
+        high: function(x) { return x; }
+      };
+    }
     basalUtil = data.basalUtil;
     return container;
   };


### PR DESCRIPTION
Small change to display Insulet bgTarget settings properly. Tideline doesn't crash previous to this change, just has a blank column in the settings, so while it'd be nice to get a blip including this change to prod before Insulet goes to prod in the uploader, nothing will break if we don't.

Ping @jh-bate for review.