### PR TITLE
fix for mmol/L units and rearrange sorting in nurseshark

### DIFF
--- a/js/plot/smbgtime.js
+++ b/js/plot/smbgtime.js
@@ -115,7 +115,7 @@ function SMBGTime (opts) {
             'class': 'd3-smbg-numbers d3-text-smbg d3-smbg-time'
           })
           .text(function(d) {
-            return d.value;
+            return format.tooltipBG(d, opts.bgUnits);
           });
 
         circles.exit().remove();

--- a/js/settings.js
+++ b/js/settings.js
@@ -27,6 +27,7 @@ module.exports = function(opts) {
   opts = opts || {};
 
   var msStartString = function(x) { return format.millisecondsAsTimeOfDay(x); };
+  var formatBG = function(x) { return format.tooltipBG({value: x}, opts.bgUnits); };
   var defaults = {
     sections: {
       basal: {
@@ -61,12 +62,12 @@ module.exports = function(opts) {
       },
       insulinSensitivity: {
         start: msStartString,
-        amount: function(x) { return format.tooltipBG({value: x}, opts.bgUnits); }
+        amount: formatBG
       },
       bgTarget: {
         start: msStartString,
-        low: function(x) { return format.tooltipBG({value: x}, opts.bgUnits); },
-        high: function(x) { return format.tooltipBG({value: x}, opts.bgUnits); }
+        low: formatBG,
+        high: formatBG
       }
     }
   };
@@ -95,8 +96,8 @@ module.exports = function(opts) {
       opts.rowHeadersByType.bgTarget = ['Start time', 'Target (' + opts.bgUnits + ')', 'High (' + opts.bgUnits + ')'];
       opts.mapsByType.bgTarget = {
         start: msStartString,
-        target: function(x) { return x; },
-        high: function(x) { return x; }
+        target: formatBG,
+        high: formatBG
       };
     }
     basalUtil = data.basalUtil;

--- a/plugins/blip/modalday/Brush.js
+++ b/plugins/blip/modalday/Brush.js
@@ -17,7 +17,8 @@ d3.chart('Brush', {
     this.base.append('g').attr('id', 'brushMainGroup');
 
     var xPosition = function(d) {
-      return chart.xScale()(d);
+      var zone = moment.tz.zone(chart.timezone());
+      return chart.xScale()(moment.utc(d).add('minutes', zone.parse(d.valueOf())).toDate());
     };
 
     this.layer('brushTicks', this.base.append('g').attr('id', 'brushTicks'), {
@@ -67,7 +68,7 @@ d3.chart('Brush', {
           .classed('centered', chart.brushTickInterval() !== 'month')
           .text(function(d) {
             var format = chart.brushTickInterval() === 'month' ? 'MMM': 'MMM D';
-            return moment.utc(d).tz(tz).format(format);
+            return moment.utc(d).format(format);
           });
         }
       }

--- a/plugins/nurseshark/index.js
+++ b/plugins/nurseshark/index.js
@@ -191,7 +191,15 @@ var nurseshark = {
       });
       log(noTimeCount, 'records removed due to not having a `time` or `timestamp` field.');
     }
-    timeIt(removeNoTime, 'removeNoTime');
+    timeIt(removeNoTime, 'Remove No Time');
+
+    function sortByTime() {
+      data = _.sortBy(data, function(d) {
+        return Date.parse(d.time);
+      });
+    }
+
+    timeIt(sortByTime, 'Sort');
 
     var uploadIDSources = {};
     var processedData = [], erroredData = [];
@@ -403,17 +411,6 @@ var nurseshark = {
       }, 'Annotate Basals');
     }
 
-    timeIt(function() {
-      processedData.sort(function(a, b) {
-        if (a.time < b.time) {
-          return -1;
-        }
-        if (a.time > b.time) {
-          return 1;
-        }
-        return 0;
-      });
-    }, 'Sort');
     var emoticon = erroredData.length ? ':(' : ':)';
     log(erroredData.length, 'items in the erroredData.', emoticon, _.countBy(erroredData, 'type'));
     log('Unique error messages:', _.unique(_.pluck(erroredData, 'errorMessage')));

--- a/test/nurseshark_test.js
+++ b/test/nurseshark_test.js
@@ -45,6 +45,30 @@ describe('nurseshark', function() {
       expect(res.processedData.length).to.equal(0);
     });
 
+    it('should sort data', function() {
+      var now = new Date();
+      var first = now.toISOString();
+      var second = new Date(now.valueOf() + 864e5).toISOString();
+      var input = [{
+        type: 'bolus',
+        a: 1,
+        z: {
+          b: 2,
+          c: 3
+        },
+        time: second,
+        timezoneOffset: 0
+      }, {
+        type: 'wizard',
+        d: [{x: 4},{y: 5}],
+        time: first,
+        timezoneOffset: 0
+      }];
+      var res = nurseshark.processData(input);
+      expect(res.processedData[0]).to.eql(_.assign({}, input[1], {source: 'Unspecified Data Source'}));
+      expect(res.processedData[1]).to.eql(_.assign({}, input[0], {source: 'Unspecified Data Source'}));
+    });
+
     describe('on overlapping Carelink uploads', function() {
       var now = new Date();
       var plusTen = new Date(now.valueOf() + 600000);


### PR DESCRIPTION
Fixed:
- properly rounded mmol/L values in weekly view values checkbox overlay
- properly rounded mmol/L values in Insulet-style target BG on the settings page
- also caught an issue with the date labels for the ticks on the scroll bar in trends view - were displaying wrong month names because they get generated as UTC but we were formatting timezone-aware

Also moved location of sort in nurseshark since new tide-whisperer may not sort results