### PR TITLE
two-week view timezone-aware display fixes

### DIFF
--- a/js/data/util/datetime.js
+++ b/js/data/util/datetime.js
@@ -154,6 +154,18 @@ var datetime = {
     return Math.ceil((end - start)/this.MS_IN_24);
   },
 
+  getUTCOfLocalPriorMidnight: function(d, timezoneName) {
+    timezoneName = timezoneName || 'UTC';
+    var local = moment.utc(d).tz(timezoneName);
+    return local.startOf('day').toDate().toISOString();
+  },
+
+  getUTCOfLocalNextMidnight: function(d, timezoneName) {
+    timezoneName = timezoneName || 'UTC';
+    var local = moment.utc(d).tz(timezoneName);
+    return new Date(local.endOf('day').valueOf() + 1).toISOString();
+  },
+
   isLessThanTwentyFourHours: function(s, e) {
     var start = new Date(s).valueOf(), end = new Date(e).valueOf();
     if (end - start < this.MS_IN_24) {

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -244,35 +244,11 @@ function TidelineData(data, opts) {
     }
     var endpoints;
     if (opts.timePrefs.timezoneAware) {
-      var firstOffset = dt.getOffset(first, opts.timePrefs.timezoneName);
-      var firstDate = first.slice(0,10), firstDateAdjusted = dt.applyOffset(first, -firstOffset).slice(0,10);
-      first = dt.applyOffset(dt.getMidnight(dt.applyOffset(first, firstOffset)), firstOffset-1440);
-      if (firstDateAdjusted >= firstDate) {
-        first = dt.addDays(first, 1);
-        // TODO: possibly remove this
-        // it is intended to catch timezones on the other side of the dateline
-        // I think that makes sense to fix the issue found here
-        // (not generating fill for the last day of data when choosing e.g., New 
-        // but I haven't fully convinced myself...
-        if (Math.abs(firstOffset) >= 720) {
-          first = dt.addDays(first, 1);
-        }
-      }
-      var lastOffset = dt.getOffset(last, opts.timePrefs.timezoneName);
-      var lastDate = dt.applyOffset(last, data[data.length - 1].timezoneOffset).slice(0,10), lastDateAdjusted = dt.applyOffset(last, -lastOffset).slice(0,10);
-      if (lastDateAdjusted > lastDate) {
-        last = dt.applyOffset(dt.getMidnight(dt.applyOffset(last, lastOffset), true), lastOffset);
-        last = dt.addDays(last, 1);
-      }
-      else {
-        if (lastDateAdjusted < last.slice(0,10)) {
-          last = dt.applyOffset(dt.getMidnight(dt.applyOffset(last, lastOffset)), lastOffset);  
-        }
-        else {
-          last = dt.applyOffset(dt.getMidnight(dt.applyOffset(last, lastOffset), true), lastOffset);
-        }
-      }
-      endpoints = [first, last];
+      var tz = opts.timePrefs.timezoneName;
+      endpoints = [
+        dt.getUTCOfLocalPriorMidnight(first, tz),
+        dt.getUTCOfLocalNextMidnight(last, tz)
+      ];
     }
     else {
       endpoints = [dt.getMidnight(first), dt.getMidnight(last, true)];

--- a/plugins/blip/chartweeklyfactory.js
+++ b/plugins/blip/chartweeklyfactory.js
@@ -83,7 +83,9 @@ function chartWeeklyFactory(el, options) {
     else {
       if (twoWeekData.length &&
           Date.parse(datetime) > Date.parse(twoWeekData[twoWeekData.length - 1].normalTime)) {
-        datetime = twoWeekData[twoWeekData.length - 1].normalTime;
+        datetime = twoWeekData[_.findLastIndex(twoWeekData, function(d) {
+          return d.twoWeekX === 0;
+        })].normalTime;
       }
       chart.data(twoWeekData, chart.options.timePrefs.timezoneAware, datetime);
     }

--- a/test/datetime_test.js
+++ b/test/datetime_test.js
@@ -276,6 +276,44 @@ describe('datetime utility', function() {
     });
   });
 
+  describe('getUTCOfLocalPriorMidnight', function() {
+    it('should be a function', function() {
+      assert.isFunction(dt.getUTCOfLocalPriorMidnight);
+    });
+
+    it('should return the input if given a UTC midnight and no timezone', function() {
+      var priorMidnight = new Date().toISOString().slice(0,10) + 'T00:00:00.000Z';
+      expect(dt.getUTCOfLocalPriorMidnight(priorMidnight)).to.equal(priorMidnight);
+    });
+
+    it('should return the UTC equivalent of the prior local midnight given a timezone', function() {
+      var datetime = '2015-03-06T14:00:00.000Z';
+      // NB: Hawaii doesn't do DST so we can hardcode the +10 offset for this test
+      var priorMidnight = '2015-03-06T10:00:00.000Z';
+      expect(dt.getUTCOfLocalPriorMidnight(datetime, 'Pacific/Honolulu')).to.equal(priorMidnight);
+    });
+  });
+
+  describe('getUTCOfLocalNextMidnight', function() {
+    it('should be a function', function() {
+      assert.isFunction(dt.getUTCOfLocalNextMidnight);
+    });
+
+    it('should return the input if given a UTC midnight and no timezone', function() {
+      var thisMidnight = new Date().toISOString().slice(0,10) + 'T00:00:00.000Z';
+      var nextMidnight = new Date(thisMidnight);
+      nextMidnight.setUTCDate(nextMidnight.getUTCDate() + 1);
+      expect(dt.getUTCOfLocalNextMidnight(thisMidnight)).to.equal(nextMidnight.toISOString());
+    });
+
+    it('should return the UTC equivalent of the prior local midnight given a timezone', function() {
+      var datetime = '2015-03-06T14:00:00.000Z';
+      // NB: Hawaii doesn't do DST so we can hardcode the +10 offset for this test
+      var nextMidnight = '2015-03-07T10:00:00.000Z';
+      expect(dt.getUTCOfLocalNextMidnight(datetime, 'Pacific/Honolulu')).to.equal(nextMidnight);
+    });
+  });
+
   describe('getOffset', function() {
     it('should be a function', function() {
       assert.isFunction(dt.getOffset);

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -202,9 +202,25 @@ describe('TidelineData', function() {
     });
 
     it('when timezoneAware, should produce a foreshortened interval for Spring Forward', function() {
+      var start = '2014-03-08T12:00:00', end = '2014-03-09T12:00:00';
       var thisTd = new TidelineData([
-        new types.SMBG({deviceTime: '2014-03-08T12:00:00'}),
-        new types.SMBG({deviceTime: '2014-03-09T12:00:00'})
+        {
+          type: 'smbg',
+          deviceTime: start,
+          time: '2014-03-08T20:00:00.000Z',
+          timezoneOffset: -480,
+          id: 'abcde',
+          units: 'mg/dL',
+          value: 100
+        }, {
+          type: 'smbg',
+          deviceTime: end,
+          time: '2014-03-09T19:00:00.000Z',
+          timezoneOffset: -420,
+          id: 'abcde',
+          units: 'mg/dL',
+          value: 101
+        }
       ], {timePrefs: {
         timezoneAware: true,
         timezoneName: 'US/Pacific'
@@ -267,8 +283,23 @@ describe('TidelineData', function() {
     it('when timezoneAware, it should produce appropriately shifted intervals: true story, bruh', function() {
       var start = '2014-12-19T08:28:00', end = '2015-03-18T05:42:00';
       var thisTd = new TidelineData([
-        new types.SMBG({deviceTime: start}),
-        new types.SMBG({deviceTime: end})
+        {
+          type: 'smbg',
+          deviceTime: start,
+          time: '2014-12-19T16:28:00.000Z',
+          timezoneOffset: -480,
+          id: 'abcde',
+          units: 'mg/dL',
+          value: 100
+        }, {
+          type: 'smbg',
+          deviceTime: end,
+          time: '2015-03-18T12:42:00.000Z',
+          timezoneOffset: -420,
+          id: 'abcde',
+          units: 'mg/dL',
+          value: 101
+        }
       ], {timePrefs: {
         timezoneAware: true,
         timezoneName: 'US/Pacific'
@@ -282,8 +313,23 @@ describe('TidelineData', function() {
     it('when timezoneAware, it should produce appropriately shifted intervals: New Zealand!', function() {
       var start = '2014-12-19T08:28:00', end = '2015-03-18T05:42:00';
       var thisTd = new TidelineData([
-        new types.SMBG({deviceTime: start}),
-        new types.SMBG({deviceTime: end})
+        {
+          type: 'smbg',
+          deviceTime: start,
+          time: '2014-12-19T16:28:00.000Z',
+          timezoneOffset: -480,
+          id: 'abcde',
+          units: 'mg/dL',
+          value: 100
+        }, {
+          type: 'smbg',
+          deviceTime: end,
+          time: '2015-03-18T12:42:00.000Z',
+          timezoneOffset: -420,
+          id: 'abcde',
+          units: 'mg/dL',
+          value: 101
+        }
       ], {timePrefs: {
         timezoneAware: true,
         timezoneName: 'Pacific/Auckland'

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -264,8 +264,8 @@ describe('TidelineData', function() {
       expect(thisTd.twoWeekData[thisTd.twoWeekData.length - 1].normalTime).to.equal('2014-09-14T21:00:00.000Z');
     });
 
-    it('when timezoneAware, it should produce appropriately shifted intervals', function() {
-      var start = '2014-01-01T12:00:00', end = '2014-01-02T12:00:00';
+    it('when timezoneAware, it should produce appropriately shifted intervals: true story, bruh', function() {
+      var start = '2014-12-19T08:28:00', end = '2015-03-18T05:42:00';
       var thisTd = new TidelineData([
         new types.SMBG({deviceTime: start}),
         new types.SMBG({deviceTime: end})
@@ -275,21 +275,23 @@ describe('TidelineData', function() {
       }});
       var twoWeekFills = _.where(thisTd.twoWeekData, {type: 'fill'});
       var firstFill = twoWeekFills[0], lastFill = twoWeekFills[twoWeekFills.length - 1];
-      var offset = new Date().getTimezoneOffset();
-      if (offset === 0) {
-        // SHAME: hack to get tests to pass on Travis UTC box
-        // really this is evidence of some weirdness in the code when you are running it
-        // in timezoneAware mode with 'UTC' as the timezone
-        // you get an extra day of fill rectangles in two-week view
-        // but nothing is actually broken and the rabbit hole isn't worth it
-        expect(firstFill.normalTime).to.be.at.most(moment.utc(end).subtract(13, 'days').tz('US/Pacific').startOf('day').toISOString());
-        expect(lastFill.normalTime).to.equal(moment.utc(end).tz('US/Pacific').hours(21).toISOString());
-      }
-      else {
-        expect(firstFill.normalTime).to.be.at.most(moment.utc(end).subtract(12, 'days').tz('US/Pacific').startOf('day').toISOString());
-        expect(lastFill.normalTime).to.equal(moment.utc(end).add(1, 'days').tz('US/Pacific').hours(21).toISOString());
-      }
-      expect(new Date(lastFill.normalEnd) - new Date(firstFill.normalTime)).to.be.at.least(864e5*14);
+      expect(firstFill.normalTime).to.equal('2014-12-19T08:00:00.000Z');
+      expect(lastFill.normalTime).to.equal('2015-03-19T04:00:00.000Z');
+    });
+
+    it('when timezoneAware, it should produce appropriately shifted intervals: New Zealand!', function() {
+      var start = '2014-12-19T08:28:00', end = '2015-03-18T05:42:00';
+      var thisTd = new TidelineData([
+        new types.SMBG({deviceTime: start}),
+        new types.SMBG({deviceTime: end})
+      ], {timePrefs: {
+        timezoneAware: true,
+        timezoneName: 'Pacific/Auckland'
+      }});
+      var twoWeekFills = _.where(thisTd.twoWeekData, {type: 'fill'});
+      var firstFill = twoWeekFills[0], lastFill = twoWeekFills[twoWeekFills.length - 1];
+      expect(firstFill.normalTime).to.equal('2014-12-19T11:00:00.000Z');
+      expect(lastFill.normalTime).to.equal('2015-03-19T08:00:00.000Z');
     });
   });
 


### PR DESCRIPTION
As first discovered and noted [here](https://trello.com/c/mP8dR3Fu), although [this](https://trello.com/c/oAn5haz7) is the appropriate card for the work.

This gets rid of some truly convoluted logic around calculating the domain for the two-week view and also fixes an issue when (as in our OmniPod test data) the domain of the pump data extends a day or so beyond the domain of the smbg data.