### PR TITLE
pass timePrefs to one-day chart builder

### DIFF
--- a/js/oneday.js
+++ b/js/oneday.js
@@ -25,7 +25,16 @@ var dt = require('./data/util/datetime');
 
 var log = require('bows')('One Day');
 
-module.exports = function(emitter) {
+module.exports = function(emitter, opts) {
+
+  opts = opts || {};
+  var defaults = {
+    timePrefs: {
+      timezoneAware: false,
+      timezoneName: 'US/Pacific'
+    }
+  };
+  _.defaults(opts, defaults);
 
   // constants
   var MS_IN_24 = 86400000;
@@ -55,9 +64,14 @@ module.exports = function(emitter) {
   emitter.on('clickInPool', function(offset) {
     var leftEdge = xScale(xScale.domain()[0]);
     var date = xScale.invert(leftEdge + offset - container.axisGutter());
-    var offsetMinutes = new Date(date).getTimezoneOffset();
-    date.setUTCMinutes(date.getUTCMinutes() + offsetMinutes);
-    emitter.emit('clickTranslatesToDate', date);
+    if (!opts.timePrefs.timezoneAware) {
+      var offsetMinutes = new Date(date).getTimezoneOffset();
+      date.setUTCMinutes(date.getUTCMinutes() + offsetMinutes);
+      emitter.emit('clickTranslatesToDate', date);
+    }
+    else {
+      emitter.emit('clickTranslatesToDate', date);
+    }
   });
 
   function container(selection) {

--- a/js/oneday.js
+++ b/js/oneday.js
@@ -67,7 +67,7 @@ module.exports = function(emitter, opts) {
     if (!opts.timePrefs.timezoneAware) {
       var offsetMinutes = new Date(date).getTimezoneOffset();
       date.setUTCMinutes(date.getUTCMinutes() + offsetMinutes);
-      emitter.emit('clickTranslatesToDate', date);
+      emitter.emit('clickTranslatesToDate', date);  
     }
     else {
       emitter.emit('clickTranslatesToDate', date);

--- a/plugins/blip/chartdailyfactory.js
+++ b/plugins/blip/chartdailyfactory.js
@@ -43,7 +43,7 @@ function chartDailyFactory(el, options) {
 
   var scales = scalesutil(options);
   var emitter = new EventEmitter();
-  var chart = tideline.oneDay(emitter);
+  var chart = tideline.oneDay(emitter, options);
   chart.emitter = emitter;
   chart.options = options;
 


### PR DESCRIPTION
Pass timePrefs to one-day chart builder so that clickTranslatesToDate adjusts for timezone-naive vs. timezone-aware display. This fixes the issue where notes are being created in blip (under the new timezone-aware display) the number of hours off as your display timezone is offset from UTC.