### PR TITLE
invalid date fix

### DIFF
--- a/js/data/util/datetime.js
+++ b/js/data/util/datetime.js
@@ -166,6 +166,15 @@ var datetime = {
     return new Date(local.endOf('day').valueOf() + 1).toISOString();
   },
 
+  isATimestamp: function(s) {
+    if (isNaN(Date.parse(s))) {
+      return false;
+    }
+    else {
+      return true;
+    }
+  },
+
   isLessThanTwentyFourHours: function(s, e) {
     var start = new Date(s).valueOf(), end = new Date(e).valueOf();
     if (end - start < this.MS_IN_24) {

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -335,11 +335,13 @@ function TidelineData(data, opts) {
             d.displayOffset = 0;
           }
           else if (d.type === 'message') {
-            var datumDt = new Date(d.time);
-            var offsetMinutes = datumDt.getTimezoneOffset();
-            datumDt.setUTCMinutes(datumDt.getUTCMinutes() - offsetMinutes);
-            d.normalTime = datumDt.toISOString();
-            d.displayOffset = 0;
+            if (dt.isATimestamp(d.time)) {
+              var datumDt = new Date(d.time);
+              var offsetMinutes = datumDt.getTimezoneOffset();
+              datumDt.setUTCMinutes(datumDt.getUTCMinutes() - offsetMinutes);
+              d.normalTime = datumDt.toISOString();
+              d.displayOffset = 0;
+            }
           }
           // timezoneOffset is an optional attribute according to the Tidepool data model
           else {

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -85,6 +85,14 @@ function TidelineData(data, opts) {
       'smbg',
       'wizard'
     ],
+    oneDayDataTypes: [
+      'basal',
+      'bolus',
+      'cbg',
+      'message',
+      'smbg',
+      'wizard'
+    ],
     timePrefs: {
       timezoneAware: false,
       timezoneName: 'US/Pacific'
@@ -161,6 +169,9 @@ function TidelineData(data, opts) {
     updateCrossFilters(this.data);
     if (_.includes(opts.diabetesDataTypes, datum.type)) {
       this.diabetesData = addAndResort(datum, this.diabetesData);
+    }
+    if (_.includes(opts.oneDayDataTypes, datum.type)) {
+      this.oneDayData = addAndResort(datum, this.oneDayData);
     }
     this.generateFillData().adjustFillsForTwoWeekView();
     return this;
@@ -262,11 +273,11 @@ function TidelineData(data, opts) {
 
   this.generateFillData = function() {
     startTimer('generateFillData');
-    var lastDatum = this.diabetesData[this.diabetesData.length - 1];
+    var lastDatum = this.oneDayData[this.oneDayData.length - 1];
     // the fill should extend past the *end* of a segment (i.e. of basal data)
     // if that's the last datum in the data
     var lastTimestamp = lastDatum.normalEnd || lastDatum.normalTime;
-    var first = new Date(this.diabetesData[0].normalTime), last = new Date(lastTimestamp);
+    var first = new Date(this.oneDayData[0].normalTime), last = new Date(lastTimestamp);
     // make sure we encapsulate the domain completely
     if (last - first < MS_IN_DAY) {
       first = d3.time.hour.utc.offset(first, -12);
@@ -426,6 +437,14 @@ function TidelineData(data, opts) {
     return d.normalTime;
   });
   endTimer('diabetesData');
+
+  startTimer('oneDayData');
+  this.oneDayData = _.sortBy(_.flatten([].concat(_.map(opts.oneDayDataTypes, function(type) {
+    return this.grouped[type] || [];
+  }, this))), function(d) {
+    return d.normalTime;
+  });
+  endTimer('oneDayData');
 
   this.setBGPrefs();
 

--- a/js/validation/message.js
+++ b/js/validation/message.js
@@ -24,6 +24,7 @@ module.exports = schema(
     parentMessage: schema().oneOf(
         schema(schema().isNull()), 
         schema(schema().isId())
-    )
+    ),
+    time: schema().isISODateTime()
   }
 );

--- a/test/datetime_test.js
+++ b/test/datetime_test.js
@@ -328,6 +328,20 @@ describe('datetime utility', function() {
     });
   });
 
+  describe('isATimestamp', function() {
+    it('should be a function', function() {
+      assert.isFunction(dt.isATimestamp);
+    });
+
+    it('should return `false` when passed `Invalid date`', function() {
+      expect(dt.isATimestamp('Invalid date')).to.be.false;
+    });
+
+    it('should return `true` when passed an ISO-formatted date string', function() {
+      expect(dt.isATimestamp(new Date().toISOString())).to.be.true;
+    });
+  });
+
   describe('isLessThanTwentyFourHours', function() {
     it('should be a function', function() {
       assert.isFunction(dt.isLessThanTwentyFourHours);

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -84,6 +84,26 @@ describe('TidelineData', function() {
     expect(messageOnly.data.length).to.equal(0);
   });
 
+  it('should filter out messages with bad timestamps', function() {
+    var data = [{
+      time: 'Invalid date',
+      messageText: 'Hi there',
+      parentMessage: null,
+      type: 'message',
+      id: 'foo',
+      source: 'Unspecified Data Source',
+      // this is a somewhat artificial example because `Invalid date` in the `time`
+      // field will actually prevent the `normalTime` and `displayOffset` from being generated
+      // but I wanted to show the validation actually operating on the lack
+      // of a valid timestamp in the `time` field rather than on the missing `displayOffset`
+      // which is what actually fails validation first IRL
+      normalTime: '2015-01-01T00:00:00.000Z',
+      displayOffset: 0
+    }];
+    var res = new TidelineData(data);
+    expect(res.grouped.message.length).to.equal(0);
+  });
+
   var dataTypes = {
     basal: new types.Basal(),
     bolus: new types.Bolus(),


### PR DESCRIPTION
This prevents errors from throwing in blip due to `Invalid date` being stored as the timestamp on a note. Described in more detail on [this Trello card](https://trello.com/c/esV2WHqD).

The final two commits contain a fix for a regression in the background fill generation (not extending to a message on the right side beyond pump and/or CGM data) I introduced in #219.