### PR TITLE
fix timechange binding

### DIFF
--- a/js/plot/timechange.js
+++ b/js/plot/timechange.js
@@ -55,7 +55,9 @@ module.exports = function(pool, opts) {
 
       var timechanges = d3.select(this)
         .selectAll('g.d3-timechange-group')
-        .data(filteredData);
+        .data(filteredData, function(d) {
+          return d.id;
+        });
 
       var timechangeGroup = timechanges.enter()
         .append('g')


### PR DESCRIPTION
When you get a chance @GordyD you'll need this fix. Without it, D3's binding of the time change events to DOM elements is dependent on sort order of the data, which is not guaranteed.

On your branch some events won't appear when you're scrolling one direction or the other. (I've been running it locally to debug time change event production so I'm looking for all events and some were not showing up.)