### PR TITLE
Adjust BG pool height ratio increase to optimum bearing in mind requi…

### DIFF
--- a/plugins/blip/chartdailyfactory.js
+++ b/plugins/blip/chartdailyfactory.js
@@ -101,7 +101,7 @@ function chartDailyFactory(el, options) {
       .labelBaseline(options.labelBaseline)
       .legend(['bg'])
       .index(chart.pools().indexOf(poolBG))
-      .heightRatio(2.5)
+      .heightRatio(2.15)
       .gutterWeight(1.0);
 
     // carbs and boluses data pool
@@ -118,7 +118,7 @@ function chartDailyFactory(el, options) {
       .labelBaseline(options.labelBaseline)
       .legend(['bolus', 'carbs'])
       .index(chart.pools().indexOf(poolBolus))
-      .heightRatio(1.0)
+      .heightRatio(1.35)
       .gutterWeight(1.0);
 
     // basal data pool


### PR DESCRIPTION
…red space needed to plot bolus + carb effectively

@jebeck Updated the height ratio for BG pool and Bolus pool to take into account the min space needed for correctly displaying bolus + carb circle.

The image below shows the max value of bolus and the carb circle encapsulated inside the bolus pool. Hopefully this is ok.

<img width="946" alt="screen shot 2015-09-03 at 00 42 40" src="https://cloud.githubusercontent.com/assets/966511/9652952/f3c163ac-51d4-11e5-846a-f91b5f637eaa.png">
