### PR TITLE
fix for Chrome change to JavaScript Date implementation

### DIFF
--- a/js/data/util/format.js
+++ b/js/data/util/format.js
@@ -209,8 +209,14 @@ var format = {
       throw new Error('You have not provided two datetime strings');
     }
 
-    var fromDate = new Date(from);
-    var toDate = new Date(to);
+    // the "from" and "to" fields of a time change are always timezone-naive
+    // timestamps by definition (b/c they are device-relative time)
+    // but some (versions) of (some) browsers like to coerce timestamps without TZ info into local time
+    // and we need to prevent that, so we use moment.utc and then use the UTC
+    // variant of all JS Date methods to ensure consistency across browsers
+    var fromDate = moment.utc(from).toDate();
+    var toDate = moment.utc(to).toDate();
+
     var type = 'Time Change';
 
     var format = 'h:mm a';

--- a/test/format_test.js
+++ b/test/format_test.js
@@ -132,12 +132,12 @@ describe('format utility', function() {
     });
 
     it('should return `Mon, Nov 17` on a UTC timestamp of midnight 11/17/2014', function() {
-      var tstr = '2014-11-17T00:00:00';
+      var tstr = '2014-11-17T00:00:00.000Z';
       expect(fmt.dayAndDate(tstr)).to.equal('Mon, Nov 17');
     });
 
     it('should return `Mon, Nov 17` on a UTC timestamp of 8 a.m. 11/17/2014 when passed a Pacific DST offset', function() {
-      var tstr = '2014-11-17T08:00:00';
+      var tstr = '2014-11-17T08:00:00.000Z';
       expect(fmt.dayAndDate(new Date(Date.parse(tstr) - 1).toISOString(), -480)).to.equal('Sun, Nov 16');
       expect(fmt.dayAndDate(tstr, -480)).to.equal('Mon, Nov 17');
     });
@@ -202,11 +202,11 @@ describe('format utility', function() {
     });
 
     it('should return `1:00 am` on a UTC timestamp at 1 am', function() {
-      expect(fmt.timestamp('2014-01-01T01:00:00')).to.equal('1:00 am');
+      expect(fmt.timestamp('2014-01-01T01:00:00.000Z')).to.equal('1:00 am');
     });
 
     it('should return `5:00 pm` on a UTC timestamp at 1 am with a Pacific non-DST offset', function() {
-      expect(fmt.timestamp('2014-01-01T01:00:00', -480)).to.equal('5:00 pm');
+      expect(fmt.timestamp('2014-01-01T01:00:00.000Z', -480)).to.equal('5:00 pm');
     });
   });
 
@@ -260,11 +260,11 @@ describe('format utility', function() {
     });
 
     it('should return `Wednesday, January 1` on a UTC timestamp at 1 am on first day of 2014', function() {
-      expect(fmt.xAxisDayText('2014-01-01T01:00:00')).to.equal('Wednesday, January 1');
+      expect(fmt.xAxisDayText('2014-01-01T01:00:00.000Z')).to.equal('Wednesday, January 1');
     });
 
     it('should return `Tuesday, December 31` on same UTC timestamp when passed a Pacific non-DST offset', function() {
-      expect(fmt.xAxisDayText('2014-01-01T01:00:00', -480)).to.equal('Tuesday, December 31');
+      expect(fmt.xAxisDayText('2014-01-01T01:00:00.000Z', -480)).to.equal('Tuesday, December 31');
     });
   });
 
@@ -274,15 +274,15 @@ describe('format utility', function() {
     });
 
     it('should return return `1 am` on a UTC timestamp at 1 am', function() {
-      expect(fmt.xAxisTickText('2014-01-01T01:00:00')).to.equal('1 am');
+      expect(fmt.xAxisTickText('2014-01-01T01:00:00.000Z')).to.equal('1 am');
     });
 
     it('should return `5 pm` on same UTC timestamp when passed a Pacific non-DST offset', function() {
-      expect(fmt.xAxisTickText('2014-01-01T01:00:00', -480)).to.equal('5 pm');
+      expect(fmt.xAxisTickText('2014-01-01T01:00:00.000Z', -480)).to.equal('5 pm');
     });
 
     it('should return `6 pm` on same UTC timestamp when passed a Pacific DST offset', function() {
-      expect(fmt.xAxisTickText('2014-04-01T01:00:00', -420)).to.equal('6 pm');
+      expect(fmt.xAxisTickText('2014-04-01T01:00:00.000Z', -420)).to.equal('6 pm');
     });
   });
 });


### PR DESCRIPTION
See links to info from Chrome's public record in Trello card: https://trello.com/c/tniKifSm

For most of the tests here, the problem was just the *tests* being lazy and relying on Chrome's (previous) quirk of treating timezone-naive timestamps as UTC. But one function `format.timeChangeInfo` did need a small implementation change, which I did in the same way it's done in sundial - using `moment.utc()` to ensure cross-browser consistency in handling of timezone-naive timestamps + a comment pointing out this necessity.