### PR TITLE
Update SummaryGroup to to be more flexible in terms of layout based on number of options.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.3.5",
+  "version": "0.3.6-alpha",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/basics/chartbasicsfactory.js
+++ b/plugins/blip/basics/chartbasicsfactory.js
@@ -57,10 +57,15 @@ var BasicsChart = React.createClass({
       var fingerstickSection = _.find(basicsData.sections, function(section) {
         return section.type === 'fingerstick';
       });
-      var calibrationSelector = _.find(fingerstickSection.selectorOptions, function(option) {
-        return option.key === 'calibration';
+
+      fingerstickSection.selectorOptions.rows.forEach(function(row) {
+        var calibrationSelector = _.find(row, function(option) {
+          return option.key === 'calibration';
+        });
+        if (calibrationSelector) {
+          calibrationSelector.active = false;
+        }
       });
-      calibrationSelector.active = false;
     }
   },
   componentWillMount: function() {

--- a/plugins/blip/basics/components/BasicsUtils.js
+++ b/plugins/blip/basics/components/BasicsUtils.js
@@ -33,6 +33,17 @@ module.exports = {
    * @return {String}
    */
   getPathToSelected: function() {
+    function findInOptions(options, filter) {
+      if (!options || !options.rows) {
+        return null;
+      }
+
+      var allOptions =  _.flatten(options.rows);
+      allOptions.push(options.primary);
+
+      return _.find(allOptions, filter);
+    }
+
     var options = this.props.selectorOptions;
     var selected = findInOptions(options, {selected: true});
 
@@ -45,18 +56,6 @@ module.exports = {
     }
 
     return null;
-
-
-    function findInOptions(options, filter) {
-      if (!options || !options.row) {
-        return null;
-      }
-
-      var allOptions =  _.flatten(options.rows);
-      allOptions.push(options.primary);
-
-      return _.find(allOptions, filter);
-    }
   },
   labelGenerator: function(opts) {
     var bgClasses = opts.bgClasses;

--- a/plugins/blip/basics/components/BasicsUtils.js
+++ b/plugins/blip/basics/components/BasicsUtils.js
@@ -34,13 +34,28 @@ module.exports = {
    */
   getPathToSelected: function() {
     var options = this.props.selectorOptions;
-    var selected = _.find(options, {selected: true});
+    var selected = findInOptions(options, {selected: true});
+
     if (selected) {
       return (selected && selected.path) ? selected.path : null;
     }
-    else {
-      var defaultOpt = _.find(options, {default: true});
+    else if (options) {
+      var defaultOpt = options.primary;
       return (defaultOpt && defaultOpt.path) ? defaultOpt.path : null;
     }
-  } 
+
+    return null;
+
+
+    function findInOptions(options, filter) {
+      if (!options || !options.row) {
+        return null;
+      }
+
+      var allOptions =  _.flatten(options.rows);
+      allOptions.push(options.primary);
+
+      return _.find(allOptions, filter);
+    }
+  }
 };

--- a/plugins/blip/basics/components/CalendarContainer.js
+++ b/plugins/blip/basics/components/CalendarContainer.js
@@ -40,7 +40,7 @@ var CalendarContainer = React.createClass({
     onSelectDay: React.PropTypes.func.isRequired,
     sectionId: React.PropTypes.string.isRequired,
     selector: React.PropTypes.func,
-    selectorOptions: React.PropTypes.array,
+    selectorOptions: React.PropTypes.object,
     timezone: React.PropTypes.string.isRequired,
     type: React.PropTypes.string.isRequired
   },
@@ -61,8 +61,12 @@ var CalendarContainer = React.createClass({
   _getSelectedSubtotal: function() {
     var options = this.props.selectorOptions;
 
-    return _.get(_.find(_.flatten(options.rows), {selected: true}), 'key', false) ||
+    if (options) {
+      return _.get(_.find(_.flatten(options.rows), {selected: true}), 'key', false) ||
       options.primary.key;
+    }
+
+    return null;
   },
   render: function() {
     var containerClass = cx('Calendar-container-' + this.props.type, {

--- a/plugins/blip/basics/components/CalendarContainer.js
+++ b/plugins/blip/basics/components/CalendarContainer.js
@@ -60,8 +60,9 @@ var CalendarContainer = React.createClass({
   },
   _getSelectedSubtotal: function() {
     var options = this.props.selectorOptions;
-    return _.get(_.find(options, {selected: true}), 'key', false) ||
-      _.get(_.find(options, {default: true}), 'key', null);
+
+    return _.get(_.find(_.flatten(options.rows), {selected: true}), 'key', false) ||
+      options.primary.key;
   },
   render: function() {
     var containerClass = cx('Calendar-container-' + this.props.type, {

--- a/plugins/blip/basics/components/misc/SummaryGroup.js
+++ b/plugins/blip/basics/components/misc/SummaryGroup.js
@@ -63,7 +63,6 @@ var SummaryGroup = React.createClass({
     );
   },
   renderOption: function(option) {
-    console.log('option', option);
     if (typeof option.active !== 'undefined' && !option.active) {
       return (<div key={option.key} className='SummaryGroup-info SummaryGroup-info-blank'></div>);
     }
@@ -92,7 +91,6 @@ var SummaryGroup = React.createClass({
         value = this.props.data[path].total;
       }
       else if (path) {
-        console.log('this.props.data[path]', path, this.props.data[path]);
         value = this.props.data[path][option.key].count;
       }
       else {

--- a/plugins/blip/basics/components/misc/SummaryGroup.js
+++ b/plugins/blip/basics/components/misc/SummaryGroup.js
@@ -65,7 +65,7 @@ var SummaryGroup = React.createClass({
   },
   renderOption: function(option) {
     if (typeof option.active !== 'undefined' && !option.active) {
-      return (<div key={option.key} className='SummaryGroup-info SummaryGroup-info-blank'></div>);
+      return null; //(<div key={option.key} className='SummaryGroup-info SummaryGroup-info-blank'></div>);
     }
 
     var classes = classnames({

--- a/plugins/blip/basics/components/misc/SummaryGroup.js
+++ b/plugins/blip/basics/components/misc/SummaryGroup.js
@@ -27,7 +27,7 @@ var SummaryGroup = React.createClass({
   propTypes: {
     data: React.PropTypes.object.isRequired,
     selectedSubtotal: React.PropTypes.string.isRequired,
-    selectorOptions: React.PropTypes.array.isRequired,
+    selectorOptions: React.PropTypes.object.isRequired,
     sectionId: React.PropTypes.string.isRequired
   },
   render: function() {
@@ -35,6 +35,7 @@ var SummaryGroup = React.createClass({
     var primaryOption = self.props.selectorOptions.primary;
     var primaryElem = null;
     if (primaryOption) {
+      primaryOption.primary = true; //need to have property present indicating option is primary
       primaryElem = this.renderOption(primaryOption);
 
       if (!self.props.selectedSubtotal) {
@@ -44,10 +45,10 @@ var SummaryGroup = React.createClass({
 
     var optionRows = self.props.selectorOptions.rows;
 
-    var others = optionRows.map(function(row) {
+    var others = optionRows.map(function(row, id) {
       var options = row.map(self.renderOption);
       return (
-        <div className="SummaryGroup-row">
+        <div key={'row-'+id} className="SummaryGroup-row">
           {options}
         </div>
       );

--- a/plugins/blip/basics/components/misc/SummaryGroup.js
+++ b/plugins/blip/basics/components/misc/SummaryGroup.js
@@ -92,6 +92,7 @@ var SummaryGroup = React.createClass({
         value = this.props.data[path].total;
       }
       else if (path) {
+        console.log('this.props.data[path]', path, this.props.data[path]);
         value = this.props.data[path][option.key].count;
       }
       else {

--- a/plugins/blip/basics/components/misc/SummaryGroup.js
+++ b/plugins/blip/basics/components/misc/SummaryGroup.js
@@ -32,25 +32,26 @@ var SummaryGroup = React.createClass({
   },
   render: function() {
     var self = this;
-
-    var primaryOption = _.find(self.props.selectorOptions, { primary: true });
+    var primaryOption = self.props.selectorOptions.primary;
     var primaryElem = null;
     if (primaryOption) {
-      primaryElem = this.renderInfo(primaryOption);
+      primaryElem = this.renderOption(primaryOption);
 
       if (!self.props.selectedSubtotal) {
         self.props.selectedSubtotal = primaryOption.key;
       }
     }
 
-    var otherOptions = _.filter(
-      self.props.selectorOptions,
-      function(row) {
-        return !row.primary;
-      }
-    );
+    var optionRows = self.props.selectorOptions.rows;
 
-    var others = otherOptions.map(self.renderInfo);
+    var others = optionRows.map(function(row) {
+      var options = row.map(self.renderOption);
+      return (
+        <div className="SummaryGroup-row">
+          {options}
+        </div>
+      );
+    });
 
     return (
       <div className="SummaryGroup-container">
@@ -61,7 +62,8 @@ var SummaryGroup = React.createClass({
       </div>
     );
   },
-  renderInfo: function(option) {
+  renderOption: function(option) {
+    console.log('option', option);
     if (typeof option.active !== 'undefined' && !option.active) {
       return (<div key={option.key} className='SummaryGroup-info SummaryGroup-info-blank'></div>);
     }

--- a/plugins/blip/basics/components/misc/SummaryGroup.js
+++ b/plugins/blip/basics/components/misc/SummaryGroup.js
@@ -109,22 +109,23 @@ var SummaryGroup = React.createClass({
       }
     }
 
+    var percentageElem = (option.percentage) ? (
+      <span className="SummaryGroup-option-percentage">
+        ({d3.format('%')(percentage)})
+      </span>
+    ) : null;
+
     var valueElem = (
       <span className="SummaryGroup-option-count">
         {value}
+        {percentageElem}
       </span>
     );
-    var percentageElem = (option.percentage) ? (
-      <span className="SummaryGroup-option-percentage">
-        {d3.format('%')(percentage)}
-      </span>
-    ) : null;
 
     return (
       <div key={option.key} className={classes}
         onClick={this.handleSelectSubtotal.bind(null, option.key)}>
         <span className="SummaryGroup-option-label">{option.label}</span>
-        {percentageElem}
         {valueElem}
       </div>
     );

--- a/plugins/blip/basics/less/CalendarContainer.less
+++ b/plugins/blip/basics/less/CalendarContainer.less
@@ -1,3 +1,5 @@
+@calendar-label-color: #BCBEC0;
+
 .corner-dates {
 	position: absolute;
 	top: 0;
@@ -31,6 +33,7 @@
 			flex: 0 1 @day-width;
 			height: @day-height;
 			position: relative;
+			color: @calendar-label-color;
 
 			margin-top: 8px;
 

--- a/plugins/blip/basics/less/misc/SummaryGroup.less
+++ b/plugins/blip/basics/less/misc/SummaryGroup.less
@@ -23,33 +23,20 @@
       padding-left: 15px;
     }
 
-    .SummaryGroup-option-percentage, .SummaryGroup-option-count {
-      float: right;
-    }
-
     .SummaryGroup-option-count {
-      text-align: left;
-      width: 33px;
+      float: right;
+      text-align: right;
+      width: 76px;
       padding-right: 15px;
+      font-weight: bold;
     }
 
     .SummaryGroup-option-percentage {
       font-size: 11px;
       text-align: right;
       min-height: 15px;
-      width: 38px;
-      margin-left: -10px;
-      padding-right: 15px;
-    }
-
-    .SummaryGroup-option-count {
-      font-weight: bold;
-    }
-
-    &.SummaryGroup-no-percentage {
-      .SummaryGroup-option-count {
-        text-align: right;
-      }
+      padding-left: 5px;
+      font-weight: normal;
     }
 
     &.SummaryGroup-info--selected {

--- a/plugins/blip/basics/less/misc/SummaryGroup.less
+++ b/plugins/blip/basics/less/misc/SummaryGroup.less
@@ -1,7 +1,7 @@
 .SummaryGroup-container {
   padding: 0px 0px 5px;
   margin: 0px 5px 10px;
-  width: 622px;
+  width: 624px;
   font-size: 12px;
   line-height: 21px;
 
@@ -72,10 +72,12 @@
     width: 489px;
   }
 
-  .SummaryGroup-info-row {
+  .SummaryGroup-row {
     display: flex;
     justify-content: flex-start;
     flex-flow: row wrap;
+
+    padding-top: 3px;
 
     .SummaryGroup-info {
       margin-right: 3px;
@@ -83,7 +85,7 @@
   }
 
   .SummaryGroup-info-primary {
-    width: 130px;
+    width: 132px;
     height: 67px;
     padding-top: 12px;
     font-size: 15px;

--- a/plugins/blip/basics/less/misc/SummaryGroup.less
+++ b/plugins/blip/basics/less/misc/SummaryGroup.less
@@ -12,6 +12,7 @@
     align-self: flex-end;
 
     width: 160px;
+    flex-grow: 1;
     padding-top: 5px;
     cursor: pointer;
     height: 32px;
@@ -70,12 +71,15 @@
   .SummaryGroup-info-others {
     height: 70px;
     width: 489px;
+    display: flex;
+    flex-flow: row wrap;
   }
 
   .SummaryGroup-row {
     display: flex;
-    justify-content: flex-start;
+    justify-content: space-around;
     flex-flow: row wrap;
+    flex-grow: 1;
 
     padding-top: 3px;
 

--- a/plugins/blip/basics/less/misc/SummaryGroup.less
+++ b/plugins/blip/basics/less/misc/SummaryGroup.less
@@ -68,12 +68,14 @@
   }
 
   .SummaryGroup-info-others {
+    height: 70px;
+    width: 489px;
+  }
+
+  .SummaryGroup-info-row {
     display: flex;
     justify-content: flex-start;
     flex-flow: row wrap;
-
-    height: 70px;
-    width: 489px;
 
     .SummaryGroup-info {
       margin-right: 3px;

--- a/plugins/blip/basics/logic/actions.js
+++ b/plugins/blip/basics/logic/actions.js
@@ -50,7 +50,7 @@ function clearSelected(opts) {
   opts.rows = opts.rows.map(function(row) {
     return row.map(function(opt) {
       return _.omit(opt, 'selected');
-    })
+    });
   });
 
   return opts;
@@ -66,7 +66,7 @@ function setSelected(opts, selectedKey) {
           opt.selected = true;
         }
         return opt;
-      })
+      });
     });
   }
 

--- a/plugins/blip/basics/logic/actions.js
+++ b/plugins/blip/basics/logic/actions.js
@@ -36,17 +36,41 @@ basicsActions.toggleSection = function(sectionName) {
   this.app.setState({sections: sections});
 };
 
-basicsActions.selectSubtotal = function(sectionName, selectedSubtotal) {
+basicsActions.selectSubtotal = function(sectionName, selectedKey) {
   var sections = _.cloneDeep(this.app.state.sections);
   var selectorOptions = sections[sectionName].selectorOptions;
-  selectorOptions = _.map(
-    selectorOptions,
-    function(opt) { return _.omit(opt, 'selected'); }
-  );
-  var selectedIndex = _.findIndex(selectorOptions, {key: selectedSubtotal});
-  selectorOptions[selectedIndex].selected = true;
-  sections[sectionName].selectorOptions = selectorOptions;
+
+  selectorOptions = clearSelected(selectorOptions);
+  sections[sectionName].selectorOptions = setSelected(selectorOptions, selectedKey);
   this.app.setState({sections: sections});
 };
+
+function clearSelected(opts) {
+  opts.primary = _.omit(opts.primary, 'selected');
+  opts.rows = opts.rows.map(function(row) {
+    return row.map(function(opt) {
+      return _.omit(opt, 'selected');
+    })
+  });
+
+  return opts;
+}
+
+function setSelected(opts, selectedKey) {
+  if (selectedKey === opts.primary.key) {
+    opts.primary.selected = true;
+  } else {
+    opts.rows = opts.rows.map(function(row) {
+      return row.map(function(opt) {
+        if (opt.key === selectedKey) {
+          opt.selected = true;
+        }
+        return opt;
+      })
+    });
+  }
+
+  return opts;
+}
 
 module.exports = basicsActions;

--- a/plugins/blip/basics/logic/classifiers.js
+++ b/plugins/blip/basics/logic/classifiers.js
@@ -93,14 +93,10 @@ module.exports = function(bgClasses) {
       var bgCategory = classifers.categorizeBg(d);
       switch (bgCategory) {
         case 'verylow':
-          tags = tags.concat(['verylow', 'belowtarget']);
+          tags.push('verylow');
           break;
-        case 'low':
-          tags.push('belowtarget');
-          break;
-        case 'high':
         case 'veryhigh':
-          tags.push('abovetarget');
+          tags.push('veryhigh');
           break;
         default:
           break;

--- a/plugins/blip/basics/logic/datamunger.js
+++ b/plugins/blip/basics/logic/datamunger.js
@@ -348,7 +348,10 @@ module.exports = function(bgClasses) {
           var section = _.find(basicsData.sections, findSectionContainingType(type));
           // wrap this in an if mostly for testing convenience
           if (section) {
-            var tags = _.rest(_.pluck(section.selectorOptions, 'key'));
+            var tags = _.flatten(section.selectorOptions.rows.map(function(row) {
+              return _.pluck(row, 'key');
+            }));
+
             var summary = {total: Object.keys(typeObj.dataByDate)
               .reduce(reduceTotalByDate(typeObj), 0)};
             _.each(tags, this._summarizeTagFn(typeObj, summary));
@@ -378,10 +381,13 @@ module.exports = function(bgClasses) {
           fsSummary.total += fsSummary[fsCategory].total;
         });
         fingerstickData.summary = fsSummary;
-        // now summarize tags and find avg events per day
-        var fsTags = _.pluck(_.filter(fsSection.selectorOptions, function(opt) {
-          return opt.path === 'smbg' && !opt.primary;
-        }), 'key');
+        
+        var fsTags = _.flatten(section.selectorOptions.rows.map(function(row) {
+          return _.pluck(_.filter(row, function(opt) {
+            return opt.path === 'smbg';
+          }, 'key'));
+        }));
+
         _.each(fsTags, this._summarizeTagFn(fingerstickData.smbg, fsSummary.smbg));
         var smbgSummary = fingerstickData.summary.smbg;
         smbgSummary.avgPerDay = this._averageExcludingMostRecentDay(

--- a/plugins/blip/basics/logic/datamunger.js
+++ b/plugins/blip/basics/logic/datamunger.js
@@ -272,6 +272,9 @@ module.exports = function(bgClasses) {
         summary[tag].percentage = summary[tag].count/summary.total;
       };
     },
+    _getRowKey: function(row) {
+      return _.pluck(row, 'key');
+    },
     _averageExcludingMostRecentDay: function(dataObj, total, mostRecentDay) {
       var mostRecentTotal = dataObj.dataByDate[mostRecentDay] ?
         dataObj.dataByDate[mostRecentDay].total : 0;
@@ -348,9 +351,7 @@ module.exports = function(bgClasses) {
           var section = _.find(basicsData.sections, findSectionContainingType(type));
           // wrap this in an if mostly for testing convenience
           if (section) {
-            var tags = _.flatten(section.selectorOptions.rows.map(function(row) {
-              return _.pluck(row, 'key');
-            }));
+            var tags = _.flatten(_.map(section.selectorOptions.rows, this._getRowKey));
 
             var summary = {total: Object.keys(typeObj.dataByDate)
               .reduce(reduceTotalByDate(typeObj), 0)};

--- a/plugins/blip/basics/logic/datamunger.js
+++ b/plugins/blip/basics/logic/datamunger.js
@@ -382,10 +382,10 @@ module.exports = function(bgClasses) {
         });
         fingerstickData.summary = fsSummary;
         
-        var fsTags = _.flatten(section.selectorOptions.rows.map(function(row) {
+        var fsTags = _.flatten(fsSection.selectorOptions.rows.map(function(row) {
           return _.pluck(_.filter(row, function(opt) {
             return opt.path === 'smbg';
-          }, 'key'));
+          }), 'key');
         }));
 
         _.each(fsTags, this._summarizeTagFn(fingerstickData.smbg, fsSummary.smbg));

--- a/plugins/blip/basics/logic/state.js
+++ b/plugins/blip/basics/logic/state.js
@@ -86,10 +86,10 @@ var basicsState = {
       selectorOptions: [
         { key: 'total', label: 'All Boluses', default: true, primary: true },
         { key: 'wizard', label: 'Calculator', percentage: true  },
-        { key: 'manual', label: 'Manual', percentage: true  },
-        { key: 'extended', label: 'Extended', percentage: true  },
         { key: 'correction', label: 'Correction', percentage: true  },
         { key: 'override', label: 'Override', percentage: true  },
+        { key: 'manual', label: 'Manual', percentage: true  },
+        { key: 'extended', label: 'Extended', percentage: true  },
         { key: 'interrupted', label : 'Interrupted', percentage: true  }
       ],
       title: 'Bolusing',

--- a/plugins/blip/basics/logic/state.js
+++ b/plugins/blip/basics/logic/state.js
@@ -111,8 +111,7 @@ var basicsState = {
         { path: 'smbg', key: 'manual', label: 'Manual', percentage: true },
         { path: 'calibration', key: 'calibration', label: 'Calibrations' },
         { path: 'smbg', key: 'verylow', label: 'Very Low', percentage: true },
-        { path: 'smbg', key: 'belowtarget', label: 'Below Target', percentage: true },
-        { path: 'smbg', key: 'abovetarget', label: 'Above Target', percentage: true }
+        { path: 'smbg', key: 'veryhigh', label: 'Very High', percentage: true }
       ],
       title: 'BG readings',
       type: 'fingerstick'

--- a/plugins/blip/basics/logic/state.js
+++ b/plugins/blip/basics/logic/state.js
@@ -41,7 +41,7 @@ var basicsState = {
       hasHover: true,
       id: 'basals',
       index: 4,
-      open: false,
+      open: true,
       selector: SummaryGroup,
       selectorOptions: [
         { key: 'total', label: 'Basal Events', default: true, primary: true },

--- a/plugins/blip/basics/logic/state.js
+++ b/plugins/blip/basics/logic/state.js
@@ -43,13 +43,15 @@ var basicsState = {
       index: 4,
       open: true,
       selector: SummaryGroup,
-      selectorOptions: [
-        { key: 'total', label: 'Basal Events', default: true, primary: true },
-        { key: 'temp', label: 'Temp Basals' },
-        { key: 'suspend', label: 'Suspends' },
-        // commented out because there's a problem with scheduleName in OmniPod data :(
-        // { key: 'scheduleChange', label: 'Schedule Changes' }
-      ],
+      selectorOptions: {
+        primary: { key: 'total', label: 'Basal Events' },
+        rows: [
+          { key: 'temp', label: 'Temp Basals' },
+          { key: 'suspend', label: 'Suspends' },
+          // commented out because there's a problem with scheduleName in OmniPod data :(
+          // { key: 'scheduleChange', label: 'Schedule Changes' }
+        ]
+      },
       title: 'Basals',
       type: 'basal'
     },
@@ -83,15 +85,21 @@ var basicsState = {
       index: 2,
       open: true,
       selector: SummaryGroup,
-      selectorOptions: [
-        { key: 'total', label: 'All Boluses', default: true, primary: true },
-        { key: 'wizard', label: 'Calculator', percentage: true  },
-        { key: 'correction', label: 'Correction', percentage: true  },
-        { key: 'override', label: 'Override', percentage: true  },
-        { key: 'manual', label: 'Manual', percentage: true  },
-        { key: 'extended', label: 'Extended', percentage: true  },
-        { key: 'interrupted', label : 'Interrupted', percentage: true  }
-      ],
+      selectorOptions: {
+        primary: { key: 'total', label: 'All Boluses' },
+        rows: [
+          [ 
+            { key: 'wizard', label: 'Calculator', percentage: true  },
+            { key: 'correction', label: 'Correction', percentage: true  },
+            { key: 'override', label: 'Override', percentage: true  }
+          ],
+          [
+            { key: 'manual', label: 'Manual', percentage: true  },
+            { key: 'extended', label: 'Extended', percentage: true  },
+            { key: 'interrupted', label : 'Interrupted', percentage: true  }
+          ]
+        ]
+      },
       title: 'Bolusing',
       type: 'bolus'
     },
@@ -105,14 +113,20 @@ var basicsState = {
       index: 1,
       open: true,
       selector: SummaryGroup,
-      selectorOptions: [
-        { path: 'smbg', key: 'total', label: 'All BGs', default: true, primary: true },
-        { path: 'smbg', key: 'meter', label: 'Meter', percentage: true },
-        { path: 'smbg', key: 'manual', label: 'Manual', percentage: true },
-        { path: 'calibration', key: 'calibration', label: 'Calibrations' },
-        { path: 'smbg', key: 'verylow', label: 'Very Low', percentage: true },
-        { path: 'smbg', key: 'veryhigh', label: 'Very High', percentage: true }
-      ],
+      selectorOptions: {
+        primary: { path: 'smbg', key: 'total', label: 'All BGs' },
+        rows: [
+          [ 
+            { path: 'smbg', key: 'meter', label: 'Meter', percentage: true },
+            { path: 'smbg', key: 'manual', label: 'Manual', percentage: true },
+            { path: 'calibration', key: 'calibration', label: 'Calibrations' }
+          ],
+          [
+            { path: 'smbg', key: 'verylow', label: 'Very Low', percentage: true },
+            { path: 'smbg', key: 'veryhigh', label: 'Very High', percentage: true }
+          ]
+        ]
+      },
       title: 'BG readings',
       type: 'fingerstick'
     },

--- a/plugins/blip/basics/logic/state.js
+++ b/plugins/blip/basics/logic/state.js
@@ -49,9 +49,9 @@ var basicsState = {
           [
             { key: 'temp', label: 'Temp Basals' },
             { key: 'suspend', label: 'Suspends' }
+            // commented out because there's a problem with scheduleName in OmniPod data :(
+            // { key: 'scheduleChange', label: 'Schedule Changes' }
           ]
-          // commented out because there's a problem with scheduleName in OmniPod data :(
-          // { key: 'scheduleChange', label: 'Schedule Changes' }
         ]
       },
       title: 'Basals',

--- a/plugins/blip/basics/logic/state.js
+++ b/plugins/blip/basics/logic/state.js
@@ -46,8 +46,10 @@ var basicsState = {
       selectorOptions: {
         primary: { key: 'total', label: 'Basal Events' },
         rows: [
-          { key: 'temp', label: 'Temp Basals' },
-          { key: 'suspend', label: 'Suspends' },
+          [
+            { key: 'temp', label: 'Temp Basals' },
+            { key: 'suspend', label: 'Suspends' }
+          ]
           // commented out because there's a problem with scheduleName in OmniPod data :(
           // { key: 'scheduleChange', label: 'Schedule Changes' }
         ]

--- a/test/basics_classifiers_test.js
+++ b/test/basics_classifiers_test.js
@@ -131,21 +131,17 @@ describe('basics classifiers', function() {
       expect(classifier({value: 25, subType: 'manual'})).to.deep.equal(['manual']);
     });
 
-    it('should classify an smbg below the very-low threshold as `verylow` and `belowtarget`', function() {
-      expect(classifier({value: 5})).to.deep.equal(['meter', 'verylow', 'belowtarget']);
+    it('should classify an smbg below the very-low threshold as `verylow`', function() {
+      expect(classifier({value: 5})).to.deep.equal(['meter', 'verylow']);
     });
 
-    it('should classify an smbg above the very-low and below the low threshold as `belowtarget`', function() {
-      expect(classifier({value: 15})).to.deep.equal(['meter', 'belowtarget']);
+    it('should not return any category tags for an in-target value', function() {
+      expect(classifier({value: 25})).to.deep.equal(['meter']);
     });
 
-    it('should classify an smbg above the target threshold as `abovetarget`', function() {
-      expect(classifier({value: 35})).to.deep.equal(['meter', 'abovetarget']);
-    });
-
-    it('should classify an smbg above the high threshold as `abovetarget`', function() {
-      expect(classifier({value: 45})).to.deep.equal(['meter', 'abovetarget']);
-      expect(classifier({value: 55})).to.deep.equal(['meter', 'abovetarget']);
+    it('should classify an smbg above the high threshold as `veryhigh`', function() {
+      expect(classifier({value: 35})).to.deep.equal(['meter']);
+      expect(classifier({value: 55})).to.deep.equal(['meter', 'veryhigh']);
     });
   });
 });

--- a/test/basics_datamunger_test.js
+++ b/test/basics_datamunger_test.js
@@ -301,6 +301,70 @@ describe('basics datamunger', function() {
     });
   });
 
+  describe('_summarizeTagFn', function() {
+    it('should be a function', function() {
+      assert.isFunction(dm._summarizeTagFn);
+    });
+
+    it('should return a function that can be used with _.each to summarize tags from subtotals', function() {
+      var dataObj = {
+        dataByDate: {
+          '2015-01-01': {
+            subtotals: {
+              foo: 2,
+              bar: 3
+            }
+          },
+          '2015-01-02': {
+            subtotals: {
+              foo: 10,
+              bar: 10
+            }
+          },
+          '2015-01-03': {
+            subtotals: {
+              foo: 0,
+              bar: 0
+            }
+          }
+        }
+      };
+      var summary = {total: 25};
+      _.each(['foo', 'bar'], dm._summarizeTagFn(dataObj, summary));
+      expect(summary).to.deep.equal({
+        total: 25,
+        foo: {count: 12, percentage: 0.48},
+        bar: {count: 13, percentage: 0.52}
+      });
+    });
+  });
+
+  describe('_averageExcludingMostRecentDay', function() {
+    it('should be a function', function() {
+      assert.isFunction(dm._averageExcludingMostRecentDay);
+    });
+
+    it('should calculate an average excluding the most recent day if data exists for it', function() {
+      var dataObj = {
+        dataByDate: {
+          '2015-01-01': {
+            total: 2
+          },
+          '2015-01-02': {
+            total: 9
+          },
+          '2015-01-03': {
+            total: 16
+          },
+          '2015-01-04': {
+            total: 1
+          }
+        }
+      };
+      expect(dm._averageExcludingMostRecentDay(dataObj, 28, '2015-01-04')).to.equal(9);
+    });
+  });
+
   describe('reduceByDay', function() {
     it('should be a function', function() {
       assert.isFunction(dm.reduceByDay);
@@ -342,11 +406,5 @@ describe('basics datamunger', function() {
         });
       });
     });
-
-    it('should classify, subtotal, and summarize smbgs and calibrations together');
-
-    it('should classify, subtotal, and summarize boluses');
-
-    it('should classify, subtotal, and summarize basals');
   });
 });


### PR DESCRIPTION
This branch is now ready for review. Includes the following:

 - refactor `selectorOptions` so that it is now an object, instead of array, containing `primary` and 'rows` fields. This has knock on effects in various parts of codebase when processing data
 - update data munging to reflect `selectorOption` changes
 - change color of day labels to #BCBEC0 as instructed by Sara
 - use flex-box to control varying widths of options based on number of options in each
 - merge in `label-generator` branch + capitalize labels