### PR TITLE
adjust validation to accept Tandem-style bgTarget in wizards and pumpSettings

### DIFF
--- a/js/validation/pumpSettings.js
+++ b/js/validation/pumpSettings.js
@@ -39,6 +39,15 @@ module.exports = schema(
     bgTarget: schema().array(schema().oneOf(
       schema(
           {
+            target: schema().number(),
+            low: schema().banned(),
+            high: schema().banned(),
+            range: schema().banned(),
+            start: schema().number().min(0).max(86400000)
+          }
+      ),
+      schema(
+          {
             low: schema().number(),
             high: schema().number(),
             range: schema().banned(),

--- a/js/validation/pumpSettings.js
+++ b/js/validation/pumpSettings.js
@@ -37,49 +37,34 @@ module.exports = schema(
       )
     ),
     bgTarget: schema().array(schema().oneOf(
-      schema(
-          {
-            target: schema().number(),
-            low: schema().banned(),
-            high: schema().banned(),
-            range: schema().banned(),
-            start: schema().number().min(0).max(86400000)
-          }
-      ),
+      // Medtronic
       schema(
           {
             low: schema().number(),
             high: schema().number(),
-            range: schema().banned(),
             start: schema().number().min(0).max(86400000),
+            range: schema().banned(),
             target: schema().banned()
           }
         ),
+      // Animas
       schema(
           {
-            low: schema().number(),
-            high: schema().number(),
-            range: schema().banned(),
-            start: schema().number().min(0).max(86400000),
-            target: schema().number()
-          }
-        ),
-      schema(
-          {
-            low: schema().banned(),
-            high: schema().banned(),
+            target: schema().number(),
             range: schema().number(),
             start: schema().number().min(0).max(86400000),
-            target: schema().number()
+            low: schema().banned(),
+            high: schema().banned()
           }
         ),
+      // OmniPod
       schema(
           {
-            low: schema().banned(),
+            target: schema().number(),
             high: schema().number(),
-            range: schema().banned(),
             start: schema().number().min(0).max(86400000),
-            target: schema().number()
+            low: schema().banned(),
+            range: schema().banned()
           }
         )
       )

--- a/js/validation/wizard.js
+++ b/js/validation/wizard.js
@@ -34,6 +34,14 @@ module.exports = schema(
     bgTarget: schema().ifExists().oneOf(
       schema(
           {
+            target: schema().number(),
+            low: schema().banned(),
+            high: schema().banned(),
+            range: schema().banned()
+          }
+      ),
+      schema(
+          {
             low: schema().number(),
             high: schema().number(),
             range: schema().banned(),

--- a/js/validation/wizard.js
+++ b/js/validation/wizard.js
@@ -32,14 +32,7 @@ module.exports = schema(
     insulinCarbRatio: schema().ifExists().number(),
     insulinSensitivity: schema().ifExists().number(),
     bgTarget: schema().ifExists().oneOf(
-      schema(
-          {
-            target: schema().number(),
-            low: schema().banned(),
-            high: schema().banned(),
-            range: schema().banned()
-          }
-      ),
+      // Medtronic
       schema(
           {
             low: schema().number(),
@@ -48,28 +41,31 @@ module.exports = schema(
             target: schema().banned()
           }
       ),
+      // Animas
       schema(
           {
-            low: schema().number(),
-            high: schema().number(),
-            range: schema().banned(),
-            target: schema().number()
+            target: schema().number(),
+            range: schema().number(),
+            low: schema().banned(),
+            high: schema().banned()
           }
       ),
+      // OmniPod
       schema(
           {
+            target: schema().number(),
+            high: schema().number(),
+            low: schema().banned(),
+            range: schema().banned()
+          }
+      ),
+      // Tandem
+      schema(
+          {
+            target: schema().number(),
             low: schema().banned(),
             high: schema().banned(),
-            range: schema().number(),
-            target: schema().number()
-          }
-      ),
-      schema(
-          {
-            low: schema().banned(),
-            high: schema().number(),
-            range: schema().banned(),
-            target: schema().number()
+            range: schema().banned()
           }
       )
     ),


### PR DESCRIPTION
What it says on the tin. Dependency of [chrome-uploader PR 167](https://github.com/tidepool-org/chrome-uploader/pull/167) but can and should be deployed thru production before that goes through.