### PR TITLE
include endpoint in basics data (+ regression test)

### DIFF
--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -514,7 +514,7 @@ function TidelineData(data, opts) {
     // is uploaded more recently (by a couple days, say) than a pump)
     function skimOffTop(groupData, end) {
       return _.takeWhile(groupData, function(d) {
-        return d.normalTime < end;
+        return d.normalTime <= end;
       });
     }
     // wrapping in an if-clause here because of the no-data
@@ -522,11 +522,11 @@ function TidelineData(data, opts) {
     if (last) {
       this.basicsData.timezone = opts.timePrefs.timezoneAware ?
         opts.timePrefs.timezoneName : 'UTC';
-      this.basicsData.dateRange = [last.time];
+      this.basicsData.dateRange = [last.normalTime];
       this.basicsData.dateRange.unshift(
         opts.timePrefs.timezoneAware ?
-          dt.findBasicsStart(last.time, opts.timePrefs.timezoneName) :
-          dt.findBasicsStart(last.time)
+          dt.findBasicsStart(last.normalTime, opts.timePrefs.timezoneName) :
+          dt.findBasicsStart(last.normalTime)
       );
       this.basicsData.days =  opts.timePrefs.timezoneAware ?
         dt.findBasicsDays(this.basicsData.dateRange, opts.timePrefs.timezoneName) :

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -313,7 +313,9 @@ describe('TidelineData', function() {
     it('should determine the date range for The Basics based on available pump data', function() {
       var dateRange = thisTd.basicsData.dateRange;
       expect(dateRange[0]).to.equal('2015-09-14T00:00:00.000Z');
-      expect(dateRange[1]).to.equal(bolus.time);
+      expect(dateRange[1]).to.equal(bolus.normalTime);
+      expect(thisTd.basicsData.data.bolus.data.length).to.equal(1);
+      expect(thisTd.basicsData.data.bolus.data[0]).to.deep.equal(bolus);
     });
 
     it('should only include CGM data types within the pump-data determined date range', function() {


### PR DESCRIPTION
Another fix, another case where `time` was being used instead of `normalTime` (and also the final data point determining the right edge of basics data was being excluded due to `<` rather than `<=`).