### PR TITLE
update to test-watch and lint for consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - "0.12.7"
   - "stable"
 script:
-  - "npm run jshint"
+  - "npm run lint"
   - "npm test"
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you want to run the example with real data to view instead of the demo data g
  1. Set your `$DATA` environment variable to the filename with `export DATA='blip-input.json'`.
  1. Start the tideline example with `npm start` as usual.
 
-### Test
+### Testing
 
 To run the tests in Chrome using [Mocha](http://visionmedia.github.io/mocha/ 'Mocha') and the [testem](https://github.com/airportyh/testem 'Test'em') test runner:
 
@@ -78,18 +78,24 @@ To run the tests in Chrome using [Mocha](http://visionmedia.github.io/mocha/ 'Mo
 $ npm test
 ```
 
-#### JSHint
+To run the unit tests in watch, use:
+
+```bash
+$ npm run test-watch
+```
+
+#### Lint
 
 Run JSHint with:
 
 ```bash
-$ npm run jshint
+$ npm run lint
 ```
 
 You can also watch files for changes and re-run automatically by starting:
 
 ```bash
-$ npm run jshint-watch
+$ npm run lint-watch
 ```
 
 ## Code Philosophy and Organization

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "scripts": {
     "test": "./node_modules/karma/bin/karma start",
     "browser-tests": "./node_modules/karma/bin/karma start --browsers Chrome",
-    "karma-watch": "./node_modules/karma/bin/karma start --no-single-run",
+    "test-watch": "./node_modules/karma/bin/karma start --no-single-run",
     "start": "BUILD_DEV=true webpack-dev-server -d --cache --colors --progress --content-base example --port 8081",
-    "jshint": "gulp jshint",
-    "jshint-watch": "gulp jshint-watch"
+    "lint": "gulp jshint",
+    "lint-watch": "gulp jshint-watch"
   },
   "dependencies": {
     "bows": "1.4.8",


### PR DESCRIPTION
@jebeck - also uses `lint` to be consistent with other repos