### PR TITLE
add a before_install to get 3.x version of npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: node_js
 node_js:
   - "0.12.7"
   - "stable"
+
+before_install: if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
+
 script:
   - "npm run lint"
   - "npm test"


### PR DESCRIPTION
Will self-merge if build passes. Since we've updated Bob to 3.x npm we need to be building with that on Travis.