### PR TITLE
include Animas-style bgTarget 'range' in BG-unit conversion

### DIFF
--- a/plugins/nurseshark/index.js
+++ b/plugins/nurseshark/index.js
@@ -365,7 +365,7 @@ function getHandlers(bgUnits) {
           for (var j = 0; j < d.bgTarget.length; ++j) {
             var current = d.bgTarget[j];
             for (var key in current) {
-              if (key !== 'range' && key !== 'start') {
+              if (key !== 'start') {
                 current[key] = translateBg(current[key]);
               }
             }
@@ -430,9 +430,7 @@ function getHandlers(bgUnits) {
         }
         if (d.bgTarget) {
           for (var key in d.bgTarget) {
-            if (key !== 'range') {
-              d.bgTarget[key] = translateBg(d.bgTarget[key]);
-            }
+            d.bgTarget[key] = translateBg(d.bgTarget[key]);
           }
         }
         if (d.insulinSensitivity) {

--- a/test/nurseshark_test.js
+++ b/test/nurseshark_test.js
@@ -285,7 +285,9 @@ describe('nurseshark', function() {
         bgInput: 15.1518112923307,
         bgTarget: {
           high: 5.550747991045533,
-          low: 5.550747991045533
+          low: 5.550747991045533,
+          target: 5.550747991045533,
+          range: 0.555074799,
         },
         insulinSensitivity: 3.7753739955227665,
         timezoneOffset: 0
@@ -294,6 +296,8 @@ describe('nurseshark', function() {
       expect(res.bgInput).to.equal(273);
       expect(res.bgTarget.low).to.equal(100);
       expect(res.bgTarget.high).to.equal(100);
+      expect(res.bgTarget.target).to.equal(100);
+      expect(res.bgTarget.range).to.equal(10);
       expect(res.insulinSensitivity).to.equal(68);
     });
 
@@ -308,7 +312,7 @@ describe('nurseshark', function() {
         },
         bgTarget: [{
           target: 6.66089758925464,
-          range: 10
+          range: 0.555074799
         }],
         insulinSensitivity: [
           {


### PR DESCRIPTION
Applies in both `pumpSettings` and `wizard` objects.

Note that [the data model docs on pumpSettings.bgTarget](http://developer.tidepool.io/data-model/device-data/types/pumpSettings.html#bgtarget) specify `range` as a unitless field, but clearly that's not what we're doing in the Animas driver. Same for the docs on `wizard`s.

CC @gniezen @darinkrauss We need to regroup on this data model issue and either update the docs or update the Animas driver.