### PR TITLE
[WIP] Basics calendar filter hovers and metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/basics/components/CalendarContainer.js
+++ b/plugins/blip/basics/components/CalendarContainer.js
@@ -43,7 +43,8 @@ var CalendarContainer = React.createClass({
     selector: React.PropTypes.func,
     selectorOptions: React.PropTypes.object,
     timezone: React.PropTypes.string.isRequired,
-    type: React.PropTypes.string.isRequired
+    type: React.PropTypes.string.isRequired,
+    trackMetric: React.PropTypes.func.isRequired,
   },
   getInitialState: function() {
     return {
@@ -102,7 +103,8 @@ var CalendarContainer = React.createClass({
       data: this.props.data[this.props.type].summary,
       selectedSubtotal: this._getSelectedSubtotal(),
       selectorOptions: this.props.selectorOptions,
-      sectionId: this.props.sectionId
+      sectionId: this.props.sectionId,
+      trackMetric: this.props.trackMetric,
     });
   },
   renderDayLabels: function() {

--- a/plugins/blip/basics/components/DashboardSection.js
+++ b/plugins/blip/basics/components/DashboardSection.js
@@ -66,7 +66,8 @@ var DashboardSection = React.createClass({
             selector={section.selector}
             selectorOptions={section.selectorOptions}
             timezone={this.props.timezone}
-            type={section.type} />
+            type={section.type}
+            trackMetric={this.props.trackMetric} />
         );
       }
       else {

--- a/plugins/blip/basics/components/misc/SummaryGroup.js
+++ b/plugins/blip/basics/components/misc/SummaryGroup.js
@@ -31,7 +31,8 @@ var SummaryGroup = React.createClass({
     data: React.PropTypes.object.isRequired,
     selectedSubtotal: React.PropTypes.string.isRequired,
     selectorOptions: React.PropTypes.object.isRequired,
-    sectionId: React.PropTypes.string.isRequired
+    sectionId: React.PropTypes.string.isRequired,
+    trackMetric: React.PropTypes.func.isRequired,
   },
   render: function() {
     var self = this;
@@ -182,7 +183,7 @@ var SummaryGroup = React.createClass({
     }
   },
   handleSelectSubtotal: function(selectedSubtotal) {
-    basicsActions.selectSubtotal(this.props.sectionId, selectedSubtotal);
+    basicsActions.selectSubtotal(this.props.sectionId, selectedSubtotal, this.props.trackMetric);
   }
 });
 

--- a/plugins/blip/basics/less/misc/SummaryGroup.less
+++ b/plugins/blip/basics/less/misc/SummaryGroup.less
@@ -43,7 +43,7 @@
       font-weight: normal;
     }
 
-    &.SummaryGroup-info--selected {
+    &.SummaryGroup-info--selected, &:hover {
       color: white;
     }
 
@@ -121,7 +121,7 @@
   .SummaryGroup-info, .SummaryGroup-info-primary {
     border-bottom: 3px solid @basal;
 
-    &.SummaryGroup-info--selected {
+    &.SummaryGroup-info--selected, &:hover {
       background-color: @basal;
     }
   }
@@ -131,7 +131,7 @@
   .SummaryGroup-info, .SummaryGroup-info-primary {
     border-bottom: 3px solid @bolus;
 
-    &.SummaryGroup-info--selected {
+    &.SummaryGroup-info--selected, &:hover {
       background-color: @bolus;
     }
   }
@@ -141,7 +141,7 @@
   .SummaryGroup-info, .SummaryGroup-info-primary {
     border-bottom: 3px solid @fingerstick;
     
-    &.SummaryGroup-info--selected {
+    &.SummaryGroup-info--selected, &:hover {
       background-color: @fingerstick;
     }
   }

--- a/plugins/blip/basics/logic/actions.js
+++ b/plugins/blip/basics/logic/actions.js
@@ -44,9 +44,11 @@ basicsActions.toggleSection = function(sectionName, metricsFunc) {
   this.app.setState({sections: sections});
 };
 
-basicsActions.selectSubtotal = function(sectionName, selectedKey) {
+basicsActions.selectSubtotal = function(sectionName, selectedKey, metricsFunc) {
   var sections = _.cloneDeep(this.app.state.sections);
   var selectorOptions = sections[sectionName].selectorOptions;
+
+  metricsFunc('filtered on ' + selectedKey);
 
   selectorOptions = clearSelected(selectorOptions);
   sections[sectionName].selectorOptions = setSelected(selectorOptions, selectedKey);


### PR DESCRIPTION
@jebeck @jh-bate When you have time, please review. It adds hover states and click tracking to the Basics calendar filters. See [Trello card](https://trello.com/c/a9tHEqoK/) for more info.

The done criteria is met*, but I marked it as a work in progress while I investigate adding tests for these filters. It doesn't look like we have anything in that regard. Is that a conscious decision, given that we're eventually phasing `tideline` out? I'm not sure how much of a headache they'll be to add, given I'm pretty new to this code.

*Well, almost. I asked Brandon if we could [modify the events](https://trello.com/c/a9tHEqoK/61-blip-basics-add-hover-interaction-on-basics-filters-dev-3-ux-1-tst-1#comment-58486b4240d47f4dcd4f3ecb), to better mesh with what we already have in the code and limit repetitiveness.