### PR TITLE
Fix "latest pump uploaded" by using computerTime

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/basics/logic/actions.js
+++ b/plugins/blip/basics/logic/actions.js
@@ -63,6 +63,7 @@ basicsActions.setSiteChangeEvent = function(sectionName, selectedKey, selectedLa
   selectorOptions = clearSelected(selectorOptions);
   sections[sectionName].selectorOptions = basicsActions.setSelected(selectorOptions, selectedKey);
   sections.siteChanges.type = selectedKey;
+  sections.siteChanges.hasHover = true;
 
   metricsFunc('Selected ' + selectedLabel);
 

--- a/plugins/blip/basics/logic/datamunger.js
+++ b/plugins/blip/basics/logic/datamunger.js
@@ -180,7 +180,7 @@ module.exports = function(bgClasses) {
       };
     },
     getLatestPumpUploaded: function(patientData) {
-      var latestPump = _.last(patientData.grouped.pumpSettings);
+      var latestPump = _.findLast(patientData.grouped.upload, {deviceTags: ['insulin-pump']});
 
       if (latestPump && latestPump.hasOwnProperty('source')) {
         return latestPump.source;

--- a/test/basics_datamunger_test.js
+++ b/test/basics_datamunger_test.js
@@ -449,9 +449,18 @@ describe('basics datamunger', function() {
     it('should return a pump with proper data', function() {
       var patientData = {
         grouped: {
-          pumpSettings: [
+          upload: [
             {
+              deviceTags: ['bgm'],
+              source: 'BGM',
+            },
+            {
+              deviceTags: ['insulin-pump'],
               source: constants.TANDEM,
+            },
+            {
+              deviceTags: ['cgm'],
+              source: 'CGM',
             },
           ],
         },

--- a/test/basics_datamunger_test.js
+++ b/test/basics_datamunger_test.js
@@ -459,13 +459,17 @@ describe('basics datamunger', function() {
               source: constants.TANDEM,
             },
             {
+              deviceTags: ['insulin-pump', 'bgm'],
+              source: constants.INSULET,
+            },
+            {
               deviceTags: ['cgm'],
               source: 'CGM',
             },
           ],
         },
       };
-      expect(dm.getLatestPumpUploaded(patientData)).to.equal(constants.TANDEM);
+      expect(dm.getLatestPumpUploaded(patientData)).to.equal(constants.INSULET);
     });
 
     it('should return null without proper data', function() {


### PR DESCRIPTION
During QA, Brandon [discovered](https://docs.google.com/document/d/1HY7S9rH0nqgJsukGrhQv5LFDaDJGfsMrn0v4Sq5vvrM/edit?disco=AAAABG3mn-0#heading=h.w48e4x8hmt0m) that when two pumps' times vary enough, the "latest uploaded pump" might not actually be the latest uploaded pump.

i.e.:
Pump A has a time of 12:03.
Pump B has a time of 12:01.

Pump A is uploaded first, followed by Pump B. Pump B **should** be the latest uploaded pump, but because we use pump time for sorting, and Pump B is two minutes behind, Pump A is the most recent uploaded. (This can be impacted by the time difference between pumps, how long each pump takes to upload, or speed at which a user uploads.)

I modified it to use `upload` for the order, filtering by pumps. Also discussed with Brandon. This code was copied from the ["Device settings" view](https://github.com/tidepool-org/blip/blob/52a83e2dc5887eeb2b1fe8cd69eb2042c9a2d5da/app/components/chart/settings.js#L93), so that is affected and should be modified, too.

(I also fixed an issue where the calendar day was not hoverable/clickable, after first picking a setting.)