### PR TITLE
Fix CareLink source

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The Uploader leaves [`source` empty](https://github.com/tidepool-org/chrome-uploader/blob/8d4a2ae37c3ba05dbd9a1380a0a921d4b9da0c2c/lib/objectBuilder.js#L467) for CareLink uploads, which causes the `source` field to [fall back](https://github.com/tidepool-org/tideline/blob/master/plugins/nurseshark/index.js#L202) to device manufacturer, [`Medtronic` for CareLink uploads](https://github.com/tidepool-org/chrome-uploader/blob/52e15c9630c32d973e090298bcc64ee0c652d6e0/lib/drivers/carelinkDriver.js#L431).

Unfortunately, the recent site change work requires knowing the difference between Medtronic pumps that have been directly uploaded ([supported](https://github.com/tidepool-org/tideline/blob/099cca28651df83b86dc7829e19c483853ec2de9/plugins/blip/basics/logic/datamunger.js#L214)) and Medtronic pumps uploaded through CareLink ([not supported](https://github.com/tidepool-org/tideline/blob/099cca28651df83b86dc7829e19c483853ec2de9/plugins/blip/basics/logic/datamunger.js#L235)).

After discussing with @darinkrauss and @jebeck, we decided a bandaid fix as part of the front-end data processing would be the best course of action. See [Trello card](https://trello.com/c/cz6yBCPG) for more info.