### PR TITLE
Merge profile before updating settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.5.23",
+  "version": "0.5.24",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/basics/logic/actions.js
+++ b/plugins/blip/basics/logic/actions.js
@@ -67,15 +67,17 @@ basicsActions.setSiteChangeEvent = function(sectionName, selectedKey, selectedLa
 
   metricsFunc('Selected ' + selectedLabel);
 
+  var newProfile = _.merge(this.app.props.patient.profile, {
+    patient: {
+      settings: {
+        siteChangeSource: selectedKey,
+      },
+    },
+  });
+
   updateBasicsSettingsFunc({
     userid: this.app.props.patient.userid,
-    profile: {
-      patient: {
-        settings: {
-          siteChangeSource: selectedKey
-        }
-      }
-    }
+    profile: newProfile,
   });
 
   this.app.setState({sections: sections});

--- a/test/blip/components/logic/actions.test.js
+++ b/test/blip/components/logic/actions.test.js
@@ -52,6 +52,14 @@ describe('actions', function() {
     props: {
       patient: {
         userid: 1,
+        profile: {
+          fullName: 'Test Patient',
+          patient: {
+            about: 'Testing Patient Update',
+            birthday: '2000-01-01',
+            diagnosisDate: '2010-01-01',
+          },
+        },
       },
     },
   };
@@ -112,7 +120,11 @@ describe('actions', function() {
       expect(updateBasicsSettings.calledWith({
         userid: app.props.patient.userid,
         profile: {
+          fullName: 'Test Patient',
           patient: {
+            about: 'Testing Patient Update',
+            birthday: '2000-01-01',
+            diagnosisDate: '2010-01-01',
             settings: {
               siteChangeSource: constants.SITE_CHANGE_CANNULA
             }


### PR DESCRIPTION
Basically the title. Merge a patient's profile before updating a setting, so it doesn't get overridden.