### PR TITLE
Move siteChangeSource to new settings metadata endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.5.25",
+  "version": "0.5.26",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/basics/chartbasicsfactory.js
+++ b/plugins/blip/basics/chartbasicsfactory.js
@@ -45,6 +45,7 @@ var BasicsChart = React.createClass({
     onSelectDay: React.PropTypes.func.isRequired,
     patient: React.PropTypes.object.isRequired,
     patientData: React.PropTypes.object.isRequired,
+    permsOfLoggedInUser: React.PropTypes.object.isRequired,
     timePrefs: React.PropTypes.object.isRequired,
     updateBasicsData: React.PropTypes.func.isRequired,
     updateBasicsSettings: React.PropTypes.func.isRequired,
@@ -98,7 +99,7 @@ var BasicsChart = React.createClass({
       dataMunger.reduceByDay(basicsData);
 
       var latestPump = dataMunger.getLatestPumpUploaded(this.props.patientData);
-      dataMunger.processInfusionSiteHistory(basicsData, latestPump, this.props.patient);
+      dataMunger.processInfusionSiteHistory(basicsData, latestPump, this.props.patient, this.props.permsOfLoggedInUser);
 
       basicsData.data.bgDistribution = dataMunger.bgDistribution(basicsData);
       var basalBolusStats = dataMunger.calculateBasalBolusStats(basicsData);

--- a/plugins/blip/basics/components/sitechange/Selector.js
+++ b/plugins/blip/basics/components/sitechange/Selector.js
@@ -123,7 +123,7 @@ var Selector = React.createClass({
   renderOptions: function() {
     var self = this;
 
-    if (!self.props.selectorMetaData.hasOwnProperty('canUpdateSettings')) {
+    if (!self.props.selectorMetaData.hasOwnProperty('canUpdateSettings') || !self.props.selectorMetaData.canUpdateSettings) {
       return;
     }
 

--- a/plugins/blip/basics/components/sitechange/Selector.js
+++ b/plugins/blip/basics/components/sitechange/Selector.js
@@ -123,7 +123,7 @@ var Selector = React.createClass({
   renderOptions: function() {
     var self = this;
 
-    if (!self.props.selectorMetaData.hasOwnProperty('canUpdateSettings') || !self.props.selectorMetaData.canUpdateSettings) {
+    if (!self.props.selectorMetaData.canUpdateSettings) {
       return;
     }
 

--- a/plugins/blip/basics/logic/actions.js
+++ b/plugins/blip/basics/logic/actions.js
@@ -67,7 +67,7 @@ basicsActions.setSiteChangeEvent = function(sectionName, selectedKey, selectedLa
 
   metricsFunc('Selected ' + selectedLabel);
 
-  var newSettings = _.merge(this.app.props.patient.settings, {
+  var newSettings = _.assign({}, this.app.props.patient.settings, {
     siteChangeSource: selectedKey,
   });
 

--- a/plugins/blip/basics/logic/actions.js
+++ b/plugins/blip/basics/logic/actions.js
@@ -67,18 +67,11 @@ basicsActions.setSiteChangeEvent = function(sectionName, selectedKey, selectedLa
 
   metricsFunc('Selected ' + selectedLabel);
 
-  var newProfile = _.merge(this.app.props.patient.profile, {
-    patient: {
-      settings: {
-        siteChangeSource: selectedKey,
-      },
-    },
+  var newSettings = _.merge(this.app.props.patient.settings, {
+    siteChangeSource: selectedKey,
   });
 
-  updateBasicsSettingsFunc({
-    userid: this.app.props.patient.userid,
-    profile: newProfile,
-  });
+  updateBasicsSettingsFunc(this.app.props.patient.userid, newSettings);
 
   this.app.setState({sections: sections});
 };

--- a/plugins/blip/basics/logic/datamunger.js
+++ b/plugins/blip/basics/logic/datamunger.js
@@ -188,24 +188,23 @@ module.exports = function(bgClasses) {
 
       return null;
     },
-    processInfusionSiteHistory: function(basicsData, latestPump, patient) {
+    processInfusionSiteHistory: function(basicsData, latestPump, patient, permissions) {
       if (!latestPump) {
         return null;
       }
 
       var {
-        permissions,
         profile: {
           fullName,
         },
         settings,
       } = patient;
 
-      var hasUploadPermission = permissions.hasOwnProperty('admin') || permissions.hasOwnProperty('custodian') || permissions.hasOwnProperty('root');
+      var canUpdateSettings = permissions.hasOwnProperty('custodian') || permissions.hasOwnProperty('root');
 
       basicsData.sections.siteChanges.selectorMetaData = {
         latestPump: latestPump,
-        canUpdateSettings: hasUploadPermission,
+        canUpdateSettings,
         patientName: fullName,
       };
 

--- a/plugins/blip/basics/logic/datamunger.js
+++ b/plugins/blip/basics/logic/datamunger.js
@@ -197,13 +197,11 @@ module.exports = function(bgClasses) {
         permissions,
         profile: {
           fullName,
-          patient: {
-            settings
-          },
         },
+        settings,
       } = patient;
 
-      var hasUploadPermission = permissions.hasOwnProperty('admin') || permissions.hasOwnProperty('root');
+      var hasUploadPermission = permissions.hasOwnProperty('admin') || permissions.hasOwnProperty('custodian') || permissions.hasOwnProperty('root');
 
       basicsData.sections.siteChanges.selectorMetaData = {
         latestPump: latestPump,

--- a/test/basics_datamunger_test.js
+++ b/test/basics_datamunger_test.js
@@ -493,10 +493,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = { root: { } };
+
       var patient = {
-        permissions: {
-          'root': {},
-        },
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -505,7 +504,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      expect(dm.processInfusionSiteHistory(basicsData, null, patient)).to.equal(null);
+      expect(dm.processInfusionSiteHistory(basicsData, null, patient, perms)).to.equal(null);
     });
 
     it('should return that logged in user has permission to update patient settings', function() {
@@ -517,10 +516,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = { root: { } };
+
       var patient = {
-        permissions: {
-          'root': {},
-        },
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -529,7 +527,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient);
+      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient, perms);
       expect(basicsData.sections.siteChanges.selectorMetaData.canUpdateSettings).to.equal(true);
     });
 
@@ -542,8 +540,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = {};
+
       var patient = {
-        permissions: {},
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -552,7 +551,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient);
+      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient, perms);
       expect(basicsData.sections.siteChanges.selectorMetaData.canUpdateSettings).to.equal(false);
     });
 
@@ -566,10 +565,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = { root: { } };
+
       var patient = {
-        permissions: {
-          'root': {},
-        },
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -578,7 +576,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      dm.processInfusionSiteHistory(basicsData, constants.TANDEM, patient);
+      dm.processInfusionSiteHistory(basicsData, constants.TANDEM, patient, perms);
       expect(basicsData.sections.siteChanges.type).to.equal(constants.SITE_CHANGE_CANNULA);
     });
 
@@ -592,10 +590,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = { root: { } };
+
       var patient = {
-        permissions: {
-          'root': {},
-        },
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -604,7 +601,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      dm.processInfusionSiteHistory(basicsData, constants.TANDEM, patient);
+      dm.processInfusionSiteHistory(basicsData, constants.TANDEM, patient, perms);
       expect(basicsData.sections.siteChanges.type).to.equal(constants.SITE_CHANGE_TUBING);
     });
 
@@ -617,10 +614,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = { root: { } };
+
       var patient = {
-        permissions: {
-          'root': {},
-        },
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -629,7 +625,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient);
+      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient, perms);
       expect(basicsData.sections.siteChanges.type).to.equal(constants.SITE_CHANGE_RESERVOIR);
     });
 
@@ -645,17 +641,16 @@ describe('basics datamunger', function() {
           sections: siteChangeSections,
         };
 
+        var perms = { root: { } };
+
         var patient = {
-          permissions: {
-            'root': {},
-          },
           profile: {
             fullName: 'Jill Jellyfish',
           },
           settings: {},
         };
 
-        dm.processInfusionSiteHistory(basicsData, pump, patient);
+        dm.processInfusionSiteHistory(basicsData, pump, patient, perms);
         expect(basicsData.sections.siteChanges.type).to.equal(constants.SECTION_TYPE_UNDECLARED);
         expect(basicsData.sections.siteChanges.settingsTogglable).to.equal(togglableState.open);
       });
@@ -670,10 +665,9 @@ describe('basics datamunger', function() {
           sections: siteChangeSections,
         };
 
+        var perms = { root: { } };
+
         var patient = {
-          permissions: {
-            'root': {},
-          },
           profile: {
             fullName: 'Jill Jellyfish',
           },
@@ -682,7 +676,7 @@ describe('basics datamunger', function() {
           },
         };
 
-        dm.processInfusionSiteHistory(basicsData, pump, patient);
+        dm.processInfusionSiteHistory(basicsData, pump, patient, perms);
         expect(basicsData.sections.siteChanges.type).to.equal(constants.SECTION_TYPE_UNDECLARED);
         expect(basicsData.sections.siteChanges.settingsTogglable).to.equal(togglableState.open);
       });
@@ -697,10 +691,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = { root: { } };
+
       var patient = {
-        permissions: {
-          'root': {},
-        },
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -709,7 +702,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient);
+      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient, perms);
       expect(basicsData.sections.siteChanges.type).to.equal(constants.SITE_CHANGE_RESERVOIR);
       expect(basicsData.sections.siteChanges.settingsTogglable).to.equal(togglableState.off);
     });

--- a/test/basics_datamunger_test.js
+++ b/test/basics_datamunger_test.js
@@ -499,13 +499,9 @@ describe('basics datamunger', function() {
         },
         profile: {
           fullName: 'Jill Jellyfish',
-          patient: {
-            profile: {
-              settings: {
-                siteChangeSource: constants.SITE_CHANGE_CANNULA,
-              },
-            },
-          },
+        },
+        settings: {
+          siteChangeSource: constants.SITE_CHANGE_CANNULA,
         },
       };
 
@@ -527,13 +523,9 @@ describe('basics datamunger', function() {
         },
         profile: {
           fullName: 'Jill Jellyfish',
-          patient: {
-            profile: {
-              settings: {
-                siteChangeSource: constants.SITE_CHANGE_CANNULA,
-              },
-            },
-          },
+        },
+        settings: {
+          siteChangeSource: constants.SITE_CHANGE_CANNULA,
         },
       };
 
@@ -554,13 +546,9 @@ describe('basics datamunger', function() {
         permissions: {},
         profile: {
           fullName: 'Jill Jellyfish',
-          patient: {
-            profile: {
-              settings: {
-                siteChangeSource: constants.SITE_CHANGE_CANNULA,
-              },
-            },
-          },
+        },
+        settings: {
+          siteChangeSource: constants.SITE_CHANGE_CANNULA,
         },
       };
 
@@ -584,11 +572,9 @@ describe('basics datamunger', function() {
         },
         profile: {
           fullName: 'Jill Jellyfish',
-          patient: {
-              settings: {
-                siteChangeSource: constants.SITE_CHANGE_CANNULA,
-              },
-          },
+        },
+        settings: {
+          siteChangeSource: constants.SITE_CHANGE_CANNULA,
         },
       };
 
@@ -612,11 +598,9 @@ describe('basics datamunger', function() {
         },
         profile: {
           fullName: 'Jill Jellyfish',
-          patient: {
-            settings: {
-              siteChangeSource: constants.SITE_CHANGE_TUBING,
-            },
-          },
+        },
+        settings: {
+          siteChangeSource: constants.SITE_CHANGE_TUBING,
         },
       };
 
@@ -639,11 +623,9 @@ describe('basics datamunger', function() {
         },
         profile: {
           fullName: 'Jill Jellyfish',
-          patient: {
-            settings: {
-              siteChangeSource: constants.SITE_CHANGE_TUBING,
-            },
-          },
+        },
+        settings: {
+          siteChangeSource: constants.SITE_CHANGE_TUBING,
         },
       };
 
@@ -669,12 +651,8 @@ describe('basics datamunger', function() {
           },
           profile: {
             fullName: 'Jill Jellyfish',
-            patient: {
-              profile: {
-                settings: {},
-              },
-            }
           },
+          settings: {},
         };
 
         dm.processInfusionSiteHistory(basicsData, pump, patient);
@@ -698,13 +676,9 @@ describe('basics datamunger', function() {
           },
           profile: {
             fullName: 'Jill Jellyfish',
-            patient: {
-              profile: {
-                settings: {
-                  siteChangeSource: constants.SITE_CHANGE_RESERVOIR,
-                },
-              },
-            }
+          },
+          settings: {
+            siteChangeSource: constants.SITE_CHANGE_RESERVOIR,
           },
         };
 
@@ -729,13 +703,9 @@ describe('basics datamunger', function() {
         },
         profile: {
           fullName: 'Jill Jellyfish',
-          patient: {
-            profile: {
-              settings: {
-                siteChangeSource: constants.SITE_CHANGE_CANNULA,
-              },
-            },
-          }
+        },
+        settings: {
+          siteChangeSource: constants.SITE_CHANGE_CANNULA,
         },
       };
 

--- a/test/blip/components/logic/actions.test.js
+++ b/test/blip/components/logic/actions.test.js
@@ -60,6 +60,9 @@ describe('actions', function() {
             diagnosisDate: '2010-01-01',
           },
         },
+        settings: {
+          previousSetting: true,
+        },
       },
     },
   };
@@ -117,20 +120,13 @@ describe('actions', function() {
       expect(updateBasicsSettings.callCount).to.equal(0);
       basicsActions.setSiteChangeEvent('siteChanges', constants.SITE_CHANGE_CANNULA, 'Cannula Prime', trackMetric, updateBasicsSettings);
       expect(updateBasicsSettings.callCount).to.equal(1);
-      expect(updateBasicsSettings.calledWith({
-        userid: app.props.patient.userid,
-        profile: {
-          fullName: 'Test Patient',
-          patient: {
-            about: 'Testing Patient Update',
-            birthday: '2000-01-01',
-            diagnosisDate: '2010-01-01',
-            settings: {
-              siteChangeSource: constants.SITE_CHANGE_CANNULA
-            }
-          }
+      expect(updateBasicsSettings.calledWith(
+        app.props.patient.userid,
+        {
+          previousSetting: true,
+          siteChangeSource: constants.SITE_CHANGE_CANNULA,
         }
-      })).to.be.true;
+      )).to.be.true;
     });
   });
 });

--- a/test/chartbasicsfactory_test.js
+++ b/test/chartbasicsfactory_test.js
@@ -40,6 +40,9 @@ describe('BasicsChart', function() {
       onSelectDay: sinon.stub(),
       patient: {},
       patientData: td,
+      permsOfLoggedInUser: {
+        view: {},
+      },
       timePrefs: {},
       updateBasicsData: sinon.stub(),
       updateBasicsSettings: sinon.stub(),
@@ -60,7 +63,7 @@ describe('BasicsChart', function() {
       TestUtils.renderIntoDocument(elem);
     }
     catch(e) {
-      expect(console.error.callCount).to.equal(9);
+      expect(console.error.callCount).to.equal(10);
     }
   });
 


### PR DESCRIPTION
This moves the `siteChangeSource` setting to a new settings metadata endpoint and fixes one bug on custodial accounts.