### PR TITLE
pass through permsOfLoggedInUser explicitly

### DIFF
--- a/plugins/blip/basics/chartbasicsfactory.js
+++ b/plugins/blip/basics/chartbasicsfactory.js
@@ -45,6 +45,7 @@ var BasicsChart = React.createClass({
     onSelectDay: React.PropTypes.func.isRequired,
     patient: React.PropTypes.object.isRequired,
     patientData: React.PropTypes.object.isRequired,
+    permsOfLoggedInUser: React.PropTypes.object.isRequired,
     timePrefs: React.PropTypes.object.isRequired,
     updateBasicsData: React.PropTypes.func.isRequired,
     updateBasicsSettings: React.PropTypes.func.isRequired,
@@ -98,7 +99,7 @@ var BasicsChart = React.createClass({
       dataMunger.reduceByDay(basicsData);
 
       var latestPump = dataMunger.getLatestPumpUploaded(this.props.patientData);
-      dataMunger.processInfusionSiteHistory(basicsData, latestPump, this.props.patient);
+      dataMunger.processInfusionSiteHistory(basicsData, latestPump, this.props.patient, this.props.permsOfLoggedInUser);
 
       basicsData.data.bgDistribution = dataMunger.bgDistribution(basicsData);
       var basalBolusStats = dataMunger.calculateBasalBolusStats(basicsData);

--- a/plugins/blip/basics/logic/datamunger.js
+++ b/plugins/blip/basics/logic/datamunger.js
@@ -188,24 +188,23 @@ module.exports = function(bgClasses) {
 
       return null;
     },
-    processInfusionSiteHistory: function(basicsData, latestPump, patient) {
+    processInfusionSiteHistory: function(basicsData, latestPump, patient, permissions) {
       if (!latestPump) {
         return null;
       }
 
       var {
-        permissions,
         profile: {
           fullName,
         },
         settings,
       } = patient;
 
-      var hasUploadPermission = permissions.hasOwnProperty('admin') || permissions.hasOwnProperty('custodian') || permissions.hasOwnProperty('root');
+      var canUpdateSettings = permissions.hasOwnProperty('admin') || permissions.hasOwnProperty('custodian') || permissions.hasOwnProperty('root');
 
       basicsData.sections.siteChanges.selectorMetaData = {
         latestPump: latestPump,
-        canUpdateSettings: hasUploadPermission,
+        canUpdateSettings,
         patientName: fullName,
       };
 

--- a/plugins/blip/basics/logic/datamunger.js
+++ b/plugins/blip/basics/logic/datamunger.js
@@ -200,7 +200,7 @@ module.exports = function(bgClasses) {
         settings,
       } = patient;
 
-      var canUpdateSettings = permissions.hasOwnProperty('admin') || permissions.hasOwnProperty('custodian') || permissions.hasOwnProperty('root');
+      var canUpdateSettings = permissions.hasOwnProperty('custodian') || permissions.hasOwnProperty('root');
 
       basicsData.sections.siteChanges.selectorMetaData = {
         latestPump: latestPump,

--- a/test/basics_datamunger_test.js
+++ b/test/basics_datamunger_test.js
@@ -493,10 +493,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = { root: { } };
+
       var patient = {
-        permissions: {
-          'root': {},
-        },
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -505,7 +504,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      expect(dm.processInfusionSiteHistory(basicsData, null, patient)).to.equal(null);
+      expect(dm.processInfusionSiteHistory(basicsData, null, patient, perms)).to.equal(null);
     });
 
     it('should return that logged in user has permission to update patient settings', function() {
@@ -517,10 +516,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = { root: { } };
+
       var patient = {
-        permissions: {
-          'root': {},
-        },
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -529,7 +527,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient);
+      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient, perms);
       expect(basicsData.sections.siteChanges.selectorMetaData.canUpdateSettings).to.equal(true);
     });
 
@@ -542,8 +540,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = {};
+
       var patient = {
-        permissions: {},
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -552,7 +551,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient);
+      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient, perms);
       expect(basicsData.sections.siteChanges.selectorMetaData.canUpdateSettings).to.equal(false);
     });
 
@@ -566,10 +565,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = { root: { } };
+
       var patient = {
-        permissions: {
-          'root': {},
-        },
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -578,7 +576,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      dm.processInfusionSiteHistory(basicsData, constants.TANDEM, patient);
+      dm.processInfusionSiteHistory(basicsData, constants.TANDEM, patient, perms);
       expect(basicsData.sections.siteChanges.type).to.equal(constants.SITE_CHANGE_CANNULA);
     });
 
@@ -592,10 +590,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = { root: { } };
+
       var patient = {
-        permissions: {
-          'root': {},
-        },
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -604,7 +601,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      dm.processInfusionSiteHistory(basicsData, constants.TANDEM, patient);
+      dm.processInfusionSiteHistory(basicsData, constants.TANDEM, patient, perms);
       expect(basicsData.sections.siteChanges.type).to.equal(constants.SITE_CHANGE_TUBING);
     });
 
@@ -617,10 +614,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = { root: { } };
+
       var patient = {
-        permissions: {
-          'root': {},
-        },
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -629,7 +625,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient);
+      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient, perms);
       expect(basicsData.sections.siteChanges.type).to.equal(constants.SITE_CHANGE_RESERVOIR);
     });
 
@@ -645,17 +641,16 @@ describe('basics datamunger', function() {
           sections: siteChangeSections,
         };
 
+        var perms = { root: { } };
+
         var patient = {
-          permissions: {
-            'root': {},
-          },
           profile: {
             fullName: 'Jill Jellyfish',
           },
           settings: {},
         };
 
-        dm.processInfusionSiteHistory(basicsData, pump, patient);
+        dm.processInfusionSiteHistory(basicsData, pump, patient, perms);
         expect(basicsData.sections.siteChanges.type).to.equal(constants.SECTION_TYPE_UNDECLARED);
         expect(basicsData.sections.siteChanges.settingsTogglable).to.equal(togglableState.open);
       });
@@ -670,10 +665,9 @@ describe('basics datamunger', function() {
           sections: siteChangeSections,
         };
 
+        var perms = { root: { } };
+
         var patient = {
-          permissions: {
-            'root': {},
-          },
           profile: {
             fullName: 'Jill Jellyfish',
           },
@@ -682,7 +676,7 @@ describe('basics datamunger', function() {
           },
         };
 
-        dm.processInfusionSiteHistory(basicsData, pump, patient);
+        dm.processInfusionSiteHistory(basicsData, pump, patient, perms);
         expect(basicsData.sections.siteChanges.type).to.equal(constants.SECTION_TYPE_UNDECLARED);
         expect(basicsData.sections.siteChanges.settingsTogglable).to.equal(togglableState.open);
       });
@@ -697,10 +691,9 @@ describe('basics datamunger', function() {
         sections: siteChangeSections,
       };
 
+      var perms = { root: { } };
+
       var patient = {
-        permissions: {
-          'root': {},
-        },
         profile: {
           fullName: 'Jill Jellyfish',
         },
@@ -709,7 +702,7 @@ describe('basics datamunger', function() {
         },
       };
 
-      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient);
+      dm.processInfusionSiteHistory(basicsData, constants.INSULET, patient, perms);
       expect(basicsData.sections.siteChanges.type).to.equal(constants.SITE_CHANGE_RESERVOIR);
       expect(basicsData.sections.siteChanges.settingsTogglable).to.equal(togglableState.off);
     });

--- a/test/chartbasicsfactory_test.js
+++ b/test/chartbasicsfactory_test.js
@@ -40,6 +40,9 @@ describe('BasicsChart', function() {
       onSelectDay: sinon.stub(),
       patient: {},
       patientData: td,
+      permsOfLoggedInUser: {
+        view: {},
+      },
       timePrefs: {},
       updateBasicsData: sinon.stub(),
       updateBasicsSettings: sinon.stub(),
@@ -60,7 +63,7 @@ describe('BasicsChart', function() {
       TestUtils.renderIntoDocument(elem);
     }
     catch(e) {
-      expect(console.error.callCount).to.equal(9);
+      expect(console.error.callCount).to.equal(10);
     }
   });
 


### PR DESCRIPTION
The previous behavior relied on the permissions of the *logged-in user* being attached to the patient (even when the patient was not the logged-in user).

This is a pretty opaque way of going about it - it derives from the /patients dashboard page (where we need to know the perms of the logged-in user to know what "action" links to display (view, upload, etc.)). So this just changes the interface to pass in the `permsOfLoggedInUser` explicitly, for less confusion. Will go with a blip PR that is not quite finished.