### PR TITLE
Deeply merge defaults

### DIFF
--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -92,7 +92,7 @@ function TidelineData(data, opts) {
     }
   };
 
-  _.defaults(opts, defaults);
+  _.defaultsDeep(opts, defaults);
   var that = this;
 
   var MS_IN_MIN = 60000, MS_IN_DAY = 864e5;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.5.26",
+  "version": "0.5.27",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",


### PR DESCRIPTION
@krystophv just a slight tweak here, so we deeply merge defaults into `opts`. This is necessary, since we're not [defining all the classes](https://github.com/tidepool-org/blip/pull/400/files#diff-89aef7d568dd2149166016136fcb9adeR256) in settings currently, and we'll need to pull the rest from the defaults object.