### PR TITLE
stop removing overlapping basals

### DIFF
--- a/plugins/nurseshark/index.js
+++ b/plugins/nurseshark/index.js
@@ -318,12 +318,6 @@ function getHandlers(bgUnits) {
       d = cloneDeep(d);
       lastEnd = lastEnd || null;
       lastBasal = lastBasal || {};
-      if (lastEnd > d.time) {
-        var err = new Error('Basal overlaps with previous.');
-        d.errorMessage = err.message;
-        d.overlapsWith = lastBasal;
-        return d;
-      }
       // NB: truthiness warranted here
       // basals with duration of 0 are *not* legitimate targets for visualization
       if (!d.duration) {

--- a/test/nurseshark_test.js
+++ b/test/nurseshark_test.js
@@ -111,26 +111,6 @@ describe('nurseshark', function() {
       expect(input[1].d[0] === output[1].d[0]).to.be.false;
     });
 
-    it('should return overlapping basals in the erroredData', function() {
-      var now = new Date();
-      var plusTen = new Date(now.valueOf() + 600000);
-      var overlapping = [{
-        type: 'basal',
-        time: now.toISOString(),
-        duration: 1200000,
-        timezoneOffset: 0
-      }, {
-        type: 'basal',
-        time: plusTen.toISOString(),
-        duration: 1200000,
-        timezoneOffset: 0
-      }];
-      var res = nurseshark.processData(overlapping).erroredData;
-      expect(res.length).to.equal(1);
-      expect(_.omit(res[0].overlapsWith, ['normalTime', 'normalEnd', 'source'])).to.eql(overlapping[0]);
-      expect(res[0].errorMessage).to.equal('Basal overlaps with previous.');
-    });
-
     it('should return off-schedule-rate and null-duration basals in the erroredData', function() {
       var now = new Date();
       var dummyDT = '2014-01-01T12:00:00';


### PR DESCRIPTION
What it says on the tin. Been meaning to open this PR for a while.

To solve one early user's data issues, we added some too-clever code to the tideline preprocessing that removes overlapping basals. This code now causes very weird experiences (no basal data or very large gaps in basal data) for users that use more than one insulin pump.

This PR removes that too-clever code so that the experience is a bit more transparent.