### PR TITLE
Distinguishing bolus override up from override down in basics view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/basics/logic/classifiers.js
+++ b/plugins/blip/basics/logic/classifiers.js
@@ -41,7 +41,7 @@ module.exports = function(bgClasses, bgUnits = MGDL_UNITS) {
         tags.push('wizard');
         if (!isNaN(recommended)) {
           if (recommended > Math.max(delivered, programmed)) {
-            tags.push('override');
+            tags.push('underride');
           }
           else if (Math.max(delivered, programmed) > recommended) {
             tags.push('override');

--- a/plugins/blip/basics/logic/state.js
+++ b/plugins/blip/basics/logic/state.js
@@ -105,9 +105,9 @@ var basicsState = {
             { key: 'override', label: 'Override', percentage: true  }
           ],
           [
-            { key: 'manual', label: 'Manual', percentage: true  },
             { key: 'extended', label: 'Extended', percentage: true  },
-            { key: 'interrupted', label : 'Interrupted', percentage: true  }
+            { key: 'interrupted', label : 'Interrupted', percentage: true  },
+            { key: 'underride', label: 'Underride', percentage: true  }
           ]
         ]
       },

--- a/test/basics_classifiers_test.js
+++ b/test/basics_classifiers_test.js
@@ -79,7 +79,7 @@ describe('basics classifiers', function() {
       expect(classifier({
         wizard: {recommended: {correction: 1.0, carb: 2.0, net: 3.0}},
         normal: 1.5
-      })).to.deep.equal(['wizard', 'override']);
+      })).to.deep.equal(['wizard', 'underride']);
     });
 
     it('should return `manual`, `extended`, and `interrupted` for an interrupted non-wizard extended bolus', function() {
@@ -94,7 +94,7 @@ describe('basics classifiers', function() {
         extended: 1.2,
         expectedExtended: 2.0,
         wizard: {recommended: {correction: 2.5, carb: 0, net: 2.5}}
-      })).to.deep.equal(['wizard', 'override', 'correction', 'interrupted', 'extended']);
+      })).to.deep.equal(['wizard', 'underride', 'correction', 'interrupted', 'extended']);
     });
 
     it('net recommendation is what counts for determining override', function() {


### PR DESCRIPTION
On the basics view, remove the 'Manual' bolus filter, and separate the the 'Overrides' filter into 'Overrides' and 'Underrides'

see https://trello.com/c/pQaZdjad for full details.
