### PR TITLE
Fix for displaying inaccurate 'High' and 'Low' smbg values

### DIFF
--- a/js/data/util/format.js
+++ b/js/data/util/format.js
@@ -32,10 +32,10 @@ var format = {
       if (annotation.code && annotation.code === 'bg/out-of-range') {
         var value = annotation.value;
         if (value === 'low') {
-          d.tooltipText = 'Lo';
+          d.tooltipText = d.type === 'cbg' ? 'Lo' : 'Low';
         }
         else if (value === 'high') {
-          d.tooltipText = 'Hi';
+          d.tooltipText = d.type === 'cbg' ? 'Hi' : 'High';
         }
       }
     }

--- a/js/plot/smbg.js
+++ b/js/plot/smbg.js
@@ -114,6 +114,8 @@ module.exports = function(pool, opts) {
   };
 
   smbg.tooltipHtml = function(group, datum) {
+    var value = format.tooltipBG(datum, opts.bgUnits);
+
     group.append('p')
       .append('span')
       .attr('class', 'secondary')
@@ -121,7 +123,7 @@ module.exports = function(pool, opts) {
     group.append('p')
       .attr('class', 'value')
       .append('span')
-      .html(format.tooltipBG(datum, opts.bgUnits));
+      .html(datum.tooltipText ? datum.tooltipText : value);
     if (!_.isEmpty(datum.subType)) {
       group.append('p')
         .append('span')

--- a/js/plot/smbgtime.js
+++ b/js/plot/smbgtime.js
@@ -225,6 +225,8 @@ function SMBGTime (opts) {
   };
 
   this.tooltipHtml = function(group, datum) {
+    var value = format.tooltipBG(datum, opts.bgUnits);
+
     group.append('p')
       .append('span')
       .attr('class', 'secondary')
@@ -232,7 +234,7 @@ function SMBGTime (opts) {
     group.append('p')
       .attr('class', 'value')
       .append('span')
-      .html(format.tooltipBG(datum, opts.bgUnits));
+      .html(datum.tooltipText ? datum.tooltipText : value);
     if (!_.isEmpty(datum.subType)) {
       group.append('p')
         .append('span')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/test/format_test.js
+++ b/test/format_test.js
@@ -87,11 +87,11 @@ describe('format utility', function() {
     it('should set the tooltip text to "Low" for smbg values below the device threshold', function() {
       var datum = {
         type: 'smbg',
-        value: 601,
+        value: 39,
         annotations: [
           {
             code: 'bg/out-of-range',
-            threshold: 600,
+            threshold: 40,
             value: 'low',
           },
         ],
@@ -105,11 +105,11 @@ describe('format utility', function() {
     it('should set the tooltip text to "Lo" for cbg values below the device threshold', function() {
       var datum = {
         type: 'cbg',
-        value: 601,
+        value: 39,
         annotations: [
           {
             code: 'bg/out-of-range',
-            threshold: 600,
+            threshold: 40,
             value: 'low',
           },
         ],

--- a/test/format_test.js
+++ b/test/format_test.js
@@ -47,6 +47,78 @@ describe('format utility', function() {
     it('should return a float string with one decimal place when no units', function() {
       expect(fmt.tooltipBG({value: 4.2222222222222222222222222})).to.equal('4.2');
     });
+
+    it('should set the tooltip text to "High" for smbg values above the device threshold', function() {
+      var datum = {
+        type: 'smbg',
+        value: 601,
+        annotations: [
+          {
+            code: 'bg/out-of-range',
+            threshold: 600,
+            value: 'high',
+          },
+        ],
+      };
+
+      fmt.tooltipBG(datum);
+
+      expect(datum.tooltipText).to.equal('High');
+    });
+
+    it('should set the tooltip text to "Hi" for cbg values above the device threshold', function() {
+      var datum = {
+        type: 'cbg',
+        value: 601,
+        annotations: [
+          {
+            code: 'bg/out-of-range',
+            threshold: 600,
+            value: 'high',
+          },
+        ],
+      };
+
+      fmt.tooltipBG(datum);
+
+      expect(datum.tooltipText).to.equal('Hi');
+    });
+
+    it('should set the tooltip text to "Low" for smbg values below the device threshold', function() {
+      var datum = {
+        type: 'smbg',
+        value: 601,
+        annotations: [
+          {
+            code: 'bg/out-of-range',
+            threshold: 600,
+            value: 'low',
+          },
+        ],
+      };
+
+      fmt.tooltipBG(datum);
+
+      expect(datum.tooltipText).to.equal('Low');
+    });
+
+    it('should set the tooltip text to "Lo" for cbg values below the device threshold', function() {
+      var datum = {
+        type: 'cbg',
+        value: 601,
+        annotations: [
+          {
+            code: 'bg/out-of-range',
+            threshold: 600,
+            value: 'low',
+          },
+        ],
+      };
+
+      fmt.tooltipBG(datum);
+
+      expect(datum.tooltipText).to.equal('Lo');
+    });
   });
 
   describe('tooltipValue', function() {


### PR DESCRIPTION
For CBG values, we show a HI/LO tooltip when the value is out of range. For SMBG values, we show value +1/-1 the threshold, e.g. when the threshold is 600 the value would be 601, and an annotation to indicate that the actual value can be higher or lower. 

We want CBG and SMBG values to have the same behaviour, ie., both should show 'High/Low' text (CBG text to be truncated to 'Hi/Lo' to fit into small tooltip circle.

Full details on trello: https://trello.com/c/p7L3RoNn

Goes hand-in-hand with https://github.com/tidepool-org/viz/pull/89