### PR TITLE
Print View - Combined (Basics, Daily, Settings)

### DIFF
--- a/dev/testpage/types.js
+++ b/dev/testpage/types.js
@@ -261,7 +261,8 @@ DeviceEvent.prototype = common;
 var Upload = function(opts) {
   opts = opts || {};
   var defaults = {
-      deviceTime: this.makeDeviceTime(),
+    deviceTime: this.makeDeviceTime(),
+    timezone: 'US/Eastern',
   };
   _.defaults(opts, defaults);
 
@@ -271,11 +272,12 @@ var Upload = function(opts) {
   this.source = opts.source;
 
   this.time = this.makeTime();
+  this.timezone = opts.timezone;
+  this.normalTime = this.makeNormalTime();
   this.createdTime = this.makeTime();
   this.timezoneOffset = this.makeTimezoneOffset();
 
   this.id = this.makeId();
-
 };
 
 Upload.prototype = common;

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -593,7 +593,6 @@ function TidelineData(data, opts) {
           )};
         }
         else if (aType === 'upload') {
-          console.log('upload data', this.grouped.upload);
           this.basicsData.data.upload = {
             data: this.grouped.upload,
           };

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -57,7 +57,7 @@ function TidelineData(data, opts) {
     CBG_PERCENT_FOR_ENOUGH: 0.75,
     CBG_MAX_DAILY: 288,
     SMBG_DAILY_MIN: 4,
-    basicsTypes: ['basal', 'bolus', 'cbg', 'smbg', 'deviceEvent', 'wizard'],
+    basicsTypes: ['basal', 'bolus', 'cbg', 'smbg', 'deviceEvent', 'wizard', 'upload'],
     bgClasses: {
       'very-low': { boundary: 55 },
       low: { boundary: 70 },
@@ -507,6 +507,7 @@ function TidelineData(data, opts) {
         case 'bolus':
         case 'cbg':
         case 'smbg':
+        case 'upload':
           return true;
         case 'deviceEvent':
           var includedSubtypes = [

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -592,6 +592,12 @@ function TidelineData(data, opts) {
             }
           )};
         }
+        else if (aType === 'upload') {
+          console.log('upload data', this.grouped.upload);
+          this.basicsData.data.upload = {
+            data: this.grouped.upload,
+          };
+        }
         else {
           this.basicsData.data[aType] = {};
           typeObj = this.basicsData.data[aType];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.6.11-basics-print-view.alpha.1",
+  "version": "0.6.11",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.6.10",
+  "version": "0.6.11-basics-print-view.alpha.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -299,6 +299,7 @@ describe('TidelineData', function() {
     var secondCBG = new types.CBG({deviceTime: '2015-10-01T14:22:00'});
     var message = new types.Message({deviceTime: '2015-10-01T16:30:00'});
     var settings = new types.Settings({deviceTime: '2015-10-01T18:00:00'});
+    var upload = new types.Upload({ deviceTime: '2015-10-01T18:00:00', deviceTags: ['insulin-pump'], source: 'Insulet' });
     var secondCalibration = {
       type: 'deviceEvent',
       subType: 'calibration',
@@ -307,8 +308,10 @@ describe('TidelineData', function() {
       normalTime: '2015-10-02T16:35:00.000Z',
       timezoneOffset: -420
     };
+
     // defaults to timezoneAware: false
     var thisTd = new TidelineData([
+      upload,
       smbg,
       firstCBG,
       firstCalibration,
@@ -339,6 +342,7 @@ describe('TidelineData', function() {
 
     it('should add all relevant data as provided', function() {
       expect(thisTd.basicsData.data.bolus.data.length).to.equal(1);
+      expect(thisTd.basicsData.data.upload.data.length).to.equal(1);
       expect(thisTd.basicsData.data.basal.data.length).to.equal(1);
       expect(thisTd.basicsData.data.cbg.data.length).to.equal(2);
       expect(thisTd.basicsData.data.calibration.data.length).to.equal(2);


### PR DESCRIPTION
See https://trello.com/c/zdyHFY0M for full details.

Goes hand-in-hand with the same-named branches in `viz` and `blip`.

Provides the upload data within the `TidelineData` export, which was required in order to render the basics and settings print views in `viz`  