### PR TITLE
Daily y-scale fix for data sets with no values above target range

### DIFF
--- a/js/plot/util/scales.js
+++ b/js/plot/util/scales.js
@@ -31,6 +31,7 @@ var scales = function(opts) {
     bolusRatio: 0.35,
     MIN_CBG: 39,
     MAX_CBG: 401,
+    TARGET_BG_BOUNDARY: 180,
     carbRadius: 14
   };
   _.defaults(opts, defaults);
@@ -38,6 +39,7 @@ var scales = function(opts) {
   if (opts.bgUnits === MMOLL_UNITS) {
     opts.MIN_CBG = opts.MIN_CBG/MGDL_PER_MMOLL;
     opts.MAX_CBG = opts.MAX_CBG/MGDL_PER_MMOLL;
+    opts.TARGET_BG_BOUNDARY = opts.TARGET_BG_BOUNDARY/MGDL_PER_MMOLL;
   }
 
   return {
@@ -51,6 +53,12 @@ var scales = function(opts) {
     },
     bg: function(data, pool, pad) {
       var ext = d3.extent(data, function(d) { return d.value; });
+      var targetBoundary = _.get(opts, 'bgClasses.target.boundary', opts.TARGET_BG_BOUNDARY);
+
+      // We need to ensure that the top of the bgScale is at least at the the target upper bound
+      // for proper rendering of datasets with no BG values above this mark.
+      ext[1] = _.max([ext[1], targetBoundary]);
+
       if (ext[1] > this.MAX_CBG || ext[0] === ext[1]) {
         return d3.scale.linear()
           .domain([0, this.MAX_CBG])

--- a/js/plot/util/scales.js
+++ b/js/plot/util/scales.js
@@ -101,22 +101,16 @@ var scales = function(opts) {
 
       var ext = d3.extent(data, function(d) { return d.value; });
       if (ext[0] === ext[1]) {
-        return defaultTicks;
+        var targetBoundary = _.get(opts, 'bgClasses.target.boundary', opts.TARGET_BG_BOUNDARY);
+        ext[1] = _.max([ext[1], targetBoundary]);
       }
       // if the min of our data is greater than any of the defaultTicks, remove that tick
-      defaultTicks.forEach(function(tick) {
-        if (ext[0] > tick) {
-          defaultTicks.shift();
-        }
-      });
-      defaultTicks.reverse();
-      // same thing for max
-      defaultTicks.forEach(function(tick) {
+      defaultTicks.forEach(function(tick, i) {
         if (ext[1] < tick) {
-          defaultTicks.shift();
+          defaultTicks.pop();
         }
       });
-      return defaultTicks.reverse();
+      return defaultTicks;
     },
     carbs: function(data, pool) {
       var scale = d3.scale.linear()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.6.16-daily-y-scale-fix.2",
+  "version": "0.6.16-daily-y-scale-fix.3",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.6.10",
+  "version": "0.6.12-daily-y-scale-fix.alpha.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.6.16-daily-y-scale-fix.3",
+  "version": "0.6.16",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.6.16-daily-y-scale-fix.1",
+  "version": "0.6.16-daily-y-scale-fix.2",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Data with no above-target values causes Y scale on daily view to be off (the very high boundary is rendered outside of the BG chart area)

See https://trello.com/c/1r7IxaiA for details.

Related PRs
https://github.com/tidepool-org/blip/pull/455
https://github.com/tidepool-org/viz/pull/94