### PR TITLE
Libre data not being calculated due to insufficient data points

### DIFF
--- a/dev/testpage/patterns.js
+++ b/dev/testpage/patterns.js
@@ -85,7 +85,8 @@ module.exports = (function() {
         var defaults = {
           days: 1,
           value: 100,
-          start: naiveTimestamp()
+          start: naiveTimestamp(),
+          deviceId: 'Dexcom_XXXXXX',
         };
         _.defaults(opts, defaults);
 
@@ -97,6 +98,7 @@ module.exports = (function() {
           current = next();
           cbgs.push(new types.CBG({
             value: opts.value,
+            deviceId: opts.deviceId,
             deviceTime: current
           }));
         }
@@ -107,7 +109,9 @@ module.exports = (function() {
         var defaults = {
           days: 1,
           value: 100,
-          start: naiveTimestamp()
+          start: naiveTimestamp(),
+          cbgMin: CBGMIN,
+          deviceId: 'Dexcom_XXXXXX',
         };
         _.defaults(opts, defaults);
 
@@ -116,9 +120,10 @@ module.exports = (function() {
         for (var i = 0; i < opts.days; ++i) {
           var j = 0;
           var next = new utils.Intervaler(start, 1000*60*5);
-          while (j < CBGMIN) {
+          while (j < opts.cbgMin) {
             cbgs.push(new types.CBG({
               value: opts.value,
+              deviceId: opts.deviceId,
               deviceTime: next()
             }));
             j++;
@@ -132,7 +137,9 @@ module.exports = (function() {
         var defaults = {
           days: 1,
           value: 8.56,
-          start: naiveTimestamp()
+          start: naiveTimestamp(),
+          cbgMin: CBGMIN,
+          deviceId: 'Dexcom_XXXXXX',
         };
         _.defaults(opts, defaults);
 
@@ -141,9 +148,10 @@ module.exports = (function() {
         for (var i = 0; i < opts.days; ++i) {
           var j = 0;
           var next = new utils.Intervaler(start, 1000*60*5);
-          while (j < CBGMIN) {
+          while (j < opts.cbgMin) {
             cbgs.push(new types.CBG({
               value: opts.value,
+              deviceId: opts.deviceId,
               deviceTime: next()
             }));
             j++;
@@ -157,7 +165,9 @@ module.exports = (function() {
         var defaults = {
           days: 1,
           value: 100,
-          start: naiveTimestamp()
+          start: naiveTimestamp(),
+          cbgMin: CBGMIN,
+          deviceId: 'Dexcom_XXXXXX',
         };
         _.defaults(opts, defaults);
 
@@ -166,9 +176,10 @@ module.exports = (function() {
         for (var i = 0; i < opts.days; ++i) {
           var j = 0;
           var next = new utils.Intervaler(start, 1000*60*5);
-          while (j < CBGMIN - 1) {
+          while (j < (opts.cbgMin - 1)) {
             cbgs.push(new types.CBG({
               value: opts.value,
+              deviceId: opts.deviceId,
               deviceTime: next()
             }));
             j++;

--- a/dev/testpage/types.js
+++ b/dev/testpage/types.js
@@ -116,6 +116,7 @@ Bolus.prototype = common;
 var CBG = function(opts) {
   opts = opts || {};
   var defaults = {
+    deviceId: 'DexG4Rec_XXXXXXXXX',
     deviceTime: this.makeDeviceTime(),
     units: MGDL_UNITS,
     value: 100
@@ -124,6 +125,7 @@ var CBG = function(opts) {
 
   this.type = 'cbg';
 
+  this.deviceId = opts.deviceId;
   this.deviceTime = opts.deviceTime;
   this.units = opts.units;
   this.value = opts.value;

--- a/js/data/bgutil.js
+++ b/js/data/bgutil.js
@@ -84,13 +84,13 @@ function BGUtil(data, opts) {
       // it to calculate average BGs is based on the expected number of readings in a day,
       // we need to adjust the weight of a for the Freestyle Libre datum, as it only
       // collects BG samples every 15 minutes as opposed the default 5 minutes from dexcom.
-      if (datum.deviceId.indexOf('AbbottFreeStyleLibre') === 0) {
+      if (datum.type === 'cbg' && datum.deviceId.indexOf('AbbottFreeStyleLibre') === 0) {
         datumWeight = 3;
       }
 
       return total + datumWeight;
     }, 0);
-  }
+  };
 
   this.filtered = function(s, e) {
     if (!currentData) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.6.13",
+  "version": "0.6.14-basics-libre-avg-cbg-fix.alpha.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/basics/logic/datamunger.js
+++ b/plugins/blip/basics/logic/datamunger.js
@@ -29,12 +29,12 @@ var { MGDL_UNITS } = require('../../../../js/data/util/constants');
 var basicsActions = require('./actions');
 var togglableState = require('../TogglableState');
 
-var bgUtil = require('../../../../js/data/bgutil');
+var BGUtil = require('../../../../js/data/bgutil');
 
 module.exports = function(bgClasses, bgUnits = MGDL_UNITS) {
 
   var classifiers = classifiersMkr(bgClasses, bgUnits);
-  var weightedCGMCount = new bgUtil([], { DAILY_MIN: constants.CGM_IN_DAY * .75 }).weightedCGMCount;
+  var weightedCGMCount = new BGUtil([], { DAILY_MIN: constants.CGM_IN_DAY * 0.75 }).weightedCGMCount;
 
   return {
     bgDistribution: function(basicsData) {

--- a/test/basics_datamunger_test.js
+++ b/test/basics_datamunger_test.js
@@ -132,29 +132,22 @@ describe('basics datamunger', function() {
       });
     });
 
-    it('should always calculate a BG distribution for smbg data, should calculate a BG distribution for cbg data if averages >= 144 readings per day, and should yield cgmStatus `calculatedCGM` when have calculated a BG distribution for FreeStyle Libre cbg data', function() {
+    it('should always calculate a BG distribution for smbg data, should calculate a BG distribution for cbg data if averages >= 48 readings per day, and should yield cgmStatus `calculatedCGM` when have calculated a BG distribution for FreeStyle Libre cbg data', function() {
       var now = new Date();
       var smbg = [
         new types.SMBG({value: 25})
       ];
       var cbg = [];
-      for (var i = 0; i < 144/3; ++i) {
+      for (var i = 0; i < 48; ++i) {
         cbg.push(new types.CBG({
+          deviceId: 'AbbottFreeStyleLibre-XXX-XXXX',
           deviceTime: new Date(now.valueOf() + i*2000).toISOString().slice(0,-5),
           value: 50
         }));
       }
 
-      const upload = [
-        {
-          source: 'Abbot',
-          deviceModel: 'FreeStyle Libre',
-          deviceTags: ['cgm', 'bgm'],
-        },
-      ];
-
       expect(dm.bgDistribution({
-        data: {smbg: {data: smbg}, cbg: {data: cbg}, upload: {data: upload}},
+        data: {smbg: {data: smbg}, cbg: {data: cbg}},
         dateRange: [d3.time.day.utc.floor(now), d3.time.day.utc.ceil(now)]
       })).to.deep.equal({
         cbg: _.defaults({veryhigh: 1}, zeroes),

--- a/test/basics_datamunger_test.js
+++ b/test/basics_datamunger_test.js
@@ -156,6 +156,41 @@ describe('basics datamunger', function() {
       });
     });
 
+    it('should always calculate a BG distribution for smbg data, should calculate a BG distribution for cbg data if averages enough readings per day, and should yield cgmStatus `calculatedCGM` when have calculated a BG distribution for mixed Dexcom and FreeStyle Libre cbg data', function() {
+      var now = new Date();
+      var smbg = [
+        new types.SMBG({value: 25})
+      ];
+      var cbg = [];
+
+      // Add half the required Dexcom datums
+      for (var i = 0; i < 72; ++i) {
+        cbg.push(new types.CBG({
+          deviceId: 'Dexcom-XXX-XXXX',
+          deviceTime: new Date(now.valueOf() + i*2000).toISOString().slice(0,-5),
+          value: 50
+        }));
+      }
+
+      // Add half the required Libre datums
+      for (var j = 0; j < 48; ++j) {
+        cbg.push(new types.CBG({
+          deviceId: 'AbbottFreeStyleLibre-XXX-XXXX',
+          deviceTime: new Date(now.valueOf() + i*2000).toISOString().slice(0,-5),
+          value: 50
+        }));
+      }
+
+      expect(dm.bgDistribution({
+        data: {smbg: {data: smbg}, cbg: {data: cbg}},
+        dateRange: [d3.time.day.utc.floor(now), d3.time.day.utc.ceil(now)]
+      })).to.deep.equal({
+        cbg: _.defaults({veryhigh: 1}, zeroes),
+        cgmStatus: 'calculatedCGM',
+        smbg: _.defaults({target: 1}, zeroes)
+      });
+    });
+
     it('should yield cgmStatus `noCGM` if no cbg data', function() {
       var now = new Date();
       var smbg = [

--- a/test/bgutil_test.js
+++ b/test/bgutil_test.js
@@ -18,6 +18,7 @@
 /* jshint esversion:6 */
 
 var chai = require('chai');
+var _ = require('lodash');
 var assert = chai.assert;
 var expect = chai.expect;
 
@@ -53,6 +54,38 @@ describe('BGUtil', function() {
 
   it('should be a (newable) constructor', function() {
     expect(bg).to.exist;
+  });
+
+  describe('weightedCGMCount', function() {
+    it('should return a count of 1 for every cgm datum by default', () => {
+      const data = _.map(_.range(0, 10), () => ({
+        deviceId: 'Dexcom_XXXXXXX',
+        type: 'cbg',
+      }));
+
+      expect(bg.weightedCGMCount(data)).to.equal(data.length);
+    });
+
+    it('should return a count of 3 for every FreeStyle Libre cgm datum by default', () => {
+      const data = _.map(_.range(0, 10), () => ({
+        deviceId: 'AbbottFreeStyleLibre_XXXXXXX',
+        type: 'cbg',
+      }));
+
+      expect(bg.weightedCGMCount(data)).to.equal(data.length * 3);
+    });
+
+    it('should properly handle a mix of FreeStyle Libre and Dexcom data', () => {
+      const data = _.map(_.range(0, 10), () => ({
+        deviceId: 'Dexcom_XXXXXXX',
+        type: 'cbg',
+      })).concat(_.map(_.range(0, 10), () => ({
+        deviceId: 'AbbottFreeStyleLibre_XXXXXXX',
+        type: 'cbg',
+      })));
+
+      expect(bg.weightedCGMCount(data)).to.equal(40);
+    });
   });
 
   describe('filtered', function() {


### PR DESCRIPTION
Libre CBG data is not being calculated in a number of locations due to having an insufficient number of data points collected in a day.

This is because the minimum data thresholds are all based on getting a certain percentage of the day covered, based on getting a new reading every 5 minutes.  The Libre, however, only gets readings every 15 minutes, so we have to reduce the minimum amount of readings expected for Libre data threefold.

This PR includes fixes for the basics, daily, and weekly web views.

See https://trello.com/c/FNlDqd1A for details.

Goes hand-in-hand with:
https://github.com/tidepool-org/blip/pull/458
https://github.com/tidepool-org/viz/pull/96