### PR TITLE
Fallback to browser timezone when invalid/unavailable from upload records

### DIFF
--- a/js/data/util/datetime.js
+++ b/js/data/util/datetime.js
@@ -1,16 +1,16 @@
 
-/* 
+/*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -131,6 +131,10 @@ var datetime = {
       .startOf('isoWeek')
       .subtract(14, 'days')
       .toDate().toISOString();
+  },
+
+  getBrowserTimezone: function() {
+    return new Intl.DateTimeFormat().resolvedOptions().timeZone;
   },
 
   getDuration: function(d1, d2) {
@@ -318,7 +322,7 @@ var datetime = {
       6: 'saturday'
     };
     return weekdays[n];
-  } 
+  }
 };
 
 module.exports = datetime;

--- a/js/oneday.js
+++ b/js/oneday.js
@@ -1,15 +1,15 @@
 /*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -31,7 +31,7 @@ module.exports = function(emitter, opts) {
   var defaults = {
     timePrefs: {
       timezoneAware: false,
-      timezoneName: 'US/Pacific'
+      timezoneName: dt.getBrowserTimezone(),
     }
   };
   _.defaults(opts, defaults);
@@ -67,7 +67,7 @@ module.exports = function(emitter, opts) {
     if (!opts.timePrefs.timezoneAware) {
       var offsetMinutes = new Date(date).getTimezoneOffset();
       date.setUTCMinutes(date.getUTCMinutes() + offsetMinutes);
-      emitter.emit('clickTranslatesToDate', date);  
+      emitter.emit('clickTranslatesToDate', date);
     }
     else {
       emitter.emit('clickTranslatesToDate', date);

--- a/js/plot/util/axes/dailyx.js
+++ b/js/plot/util/axes/dailyx.js
@@ -1,15 +1,15 @@
 /*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -33,7 +33,7 @@ module.exports = function(pool, opts) {
     longTickMultiplier: 2.5,
     timePrefs: {
       timezoneAware: false,
-      timezoneName: 'US/Pacific'
+      timezoneName: dt.getBrowserTimezone(),
     }
   };
 

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -74,7 +74,7 @@ function TidelineData(data, opts) {
     ],
     timePrefs: {
       timezoneAware: false,
-      timezoneName: 'US/Pacific'
+      timezoneName: dt.getBrowserTimezone(),
     }
   };
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function (config) {
         timeout: 4000
       },
     },
-    frameworks: [ 'mocha', 'sinon', 'chai' ], // Mocha is our testing framework of choice
+    frameworks: [ 'mocha', 'sinon', 'chai', 'intl-shim' ], // Mocha is our testing framework of choice
     files: [
       'test/index.js'
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.7.1-trends-time-fix.1",
+  "version": "0.7.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp": "3.9.1",
     "gulp-jshint": "2.0.1",
     "gulp-react": "3.1.0",
+    "intl": "1.2.5",
     "jshint": "2.9.3",
     "jshint-stylish": "2.2.1",
     "json-loader": "0.5.4",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "karma": "1.2.0",
     "karma-chai": "0.1.0",
     "karma-chrome-launcher": "2.0.0",
+    "karma-intl-shim": "1.0.3",
     "karma-mocha": "1.1.1",
     "karma-mocha-reporter": "2.1.0",
     "karma-phantomjs-launcher": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.7.0",
+  "version": "0.7.1-trends-time-fix.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/chartdailyfactory.js
+++ b/plugins/blip/chartdailyfactory.js
@@ -26,6 +26,7 @@ var EventEmitter = require('events').EventEmitter;
 var tideline = require('../../js/index');
 var fill = tideline.plot.util.fill;
 var scalesutil = tideline.plot.util.scales;
+var dt = tideline.data.util.datetime;
 var { MGDL_UNITS } = require('../../js/data/util/constants');
 
 // Create a 'One Day' chart object that is a wrapper around Tideline components
@@ -39,7 +40,7 @@ function chartDailyFactory(el, options) {
     labelBaseline: 4,
     timePrefs: {
       timezoneAware: false,
-      timezoneName: 'US/Pacific'
+      timezoneName: dt.getBrowserTimezone(),
     }
   };
   _.defaults(options, defaults);

--- a/plugins/blip/chartweeklyfactory.js
+++ b/plugins/blip/chartweeklyfactory.js
@@ -36,7 +36,7 @@ function chartWeeklyFactory(el, options) {
     bgUnits: MGDL_UNITS,
     timePrefs: {
       timezoneAware: false,
-      timezoneName: 'US/Pacific'
+      timezoneName: dt.getBrowserTimezone(),
     }
   };
   _.defaults(options, defaults);

--- a/test/datetime_test.js
+++ b/test/datetime_test.js
@@ -1,15 +1,15 @@
 /*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -268,6 +268,21 @@ describe('datetime utility', function() {
       // just over threshold into new UTC week
       expect(dt.findBasicsStart('2015-09-14T00:01:00.000Z'))
         .to.equal('2015-08-31T00:00:00.000Z');
+    });
+  });
+
+  describe('getBrowserTimezone', function() {
+    it('should be a function', function() {
+      assert.isFunction(dt.getBrowserTimezone);
+    });
+
+    it('should return the browser timezone', function() {
+      sinon.stub(Intl, 'DateTimeFormat').returns({
+        resolvedOptions: function() {
+          return { timeZone: 'browserTimezone' };
+        },
+      });
+      expect(dt.getBrowserTimezone()).to.equal('browserTimezone');
     });
   });
 

--- a/test/datetime_test.js
+++ b/test/datetime_test.js
@@ -15,6 +15,8 @@
  * == BSD2 LICENSE ==
  */
 
+/* global sinon */
+
 var chai = require('chai');
 var assert = chai.assert;
 var expect = chai.expect;
@@ -277,12 +279,13 @@ describe('datetime utility', function() {
     });
 
     it('should return the browser timezone', function() {
-      sinon.stub(Intl, 'DateTimeFormat').returns({
+      var DateTimeFormatStub = sinon.stub(Intl, 'DateTimeFormat').returns({
         resolvedOptions: function() {
           return { timeZone: 'browserTimezone' };
         },
       });
       expect(dt.getBrowserTimezone()).to.equal('browserTimezone');
+      DateTimeFormatStub.restore();
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,7 @@ require('./polyfill/function.prototype.bind');
 
 /* plugins/ */
 require('./chartbasicsfactory_test');
+require('intl/locale-data/jsonp/en.js');
 
 
 // DOM not required

--- a/yarn.lock
+++ b/yarn.lock
@@ -2694,6 +2694,10 @@ interpret@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
 
+intl@^1.0.1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
+
 invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
@@ -3045,6 +3049,12 @@ karma-chrome-launcher@2.0.0:
   dependencies:
     fs-access "^1.0.0"
     which "^1.2.1"
+
+karma-intl-shim@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/karma-intl-shim/-/karma-intl-shim-1.0.3.tgz#f07ab86b644a7c2c2a3299f38d40ed49af7ec0f0"
+  dependencies:
+    intl "^1.0.1"
 
 karma-mocha-reporter@2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2694,7 +2694,7 @@ interpret@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
 
-intl@^1.0.1:
+intl@1.2.5, intl@^1.0.1:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
 


### PR DESCRIPTION
See https://trello.com/c/98DFbS3V for details.

This part of the PR is mostly 'housekeeping'.  There were a lot of places hardcoding 'US/Pacific' as the default timezone when not provided as function arguments.  To my knowledge, this shouldn't occur in practice, however, just in case, I wanted it to fall back to the browser timezone to be consistent with the other repos.

Related PRs:
tidepool-org/blip/pull/471
tidepool-org/viz/pull/101