### PR TITLE
Update glucose defaults to reflect standards

### DIFF
--- a/js/data/bgutil.js
+++ b/js/data/bgutil.js
@@ -30,10 +30,10 @@ function BGUtil(data, opts) {
   opts = opts || {};
   var defaults = {
     bgClasses: {
-      'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
-      low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
-      target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
-      high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
+    low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
+    target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
+    high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
     },
     bgUnits: MGDL_UNITS
   };

--- a/js/data/bgutil.js
+++ b/js/data/bgutil.js
@@ -23,17 +23,17 @@ var crossfilter = require('crossfilter');
 var datetime = require('./util/datetime');
 var categorizer = require('./util/categorize');
 
-var { MGDL_UNITS, MMOLL_UNITS } = require('../data/util/constants');
+var { MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS } = require('../data/util/constants');
 
 function BGUtil(data, opts) {
 
   opts = opts || {};
   var defaults = {
     bgClasses: {
-      'very-low': { boundary: 54 },
-      low: { boundary: 70 },
-      target: { boundary: 180 },
-      high: { boundary: 250 },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
     },
     bgUnits: MGDL_UNITS
   };

--- a/js/data/bgutil.js
+++ b/js/data/bgutil.js
@@ -30,10 +30,10 @@ function BGUtil(data, opts) {
   opts = opts || {};
   var defaults = {
     bgClasses: {
-      'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
-    low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
-    target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
-    high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow },
+    low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
+    target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
+    high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
     },
     bgUnits: MGDL_UNITS
   };

--- a/js/data/bgutil.js
+++ b/js/data/bgutil.js
@@ -30,10 +30,10 @@ function BGUtil(data, opts) {
   opts = opts || {};
   var defaults = {
     bgClasses: {
-      'very-low': { boundary: 55 },
+      'very-low': { boundary: 54 },
       low: { boundary: 70 },
       target: { boundary: 180 },
-      high: { boundary: 300 },
+      high: { boundary: 250 },
     },
     bgUnits: MGDL_UNITS
   };

--- a/js/data/bgutil.js
+++ b/js/data/bgutil.js
@@ -31,9 +31,9 @@ function BGUtil(data, opts) {
   var defaults = {
     bgClasses: {
       'very-low': { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow },
-    low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
-    target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
-    high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
+      low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
     },
     bgUnits: MGDL_UNITS
   };

--- a/js/data/util/categorize.js
+++ b/js/data/util/categorize.js
@@ -32,7 +32,7 @@ var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
 
   if (bgUnits === MMOLL_UNITS) {
     _.forOwn(defaults, function(value, key) {
-      defaults[key].boundary = d3.format('.f')(value.boundary/MGDL_PER_MMOLL);
+      defaults[key].boundary = d3.format('d')(value.boundary/MGDL_PER_MMOLL);
     });
   }
 

--- a/js/data/util/categorize.js
+++ b/js/data/util/categorize.js
@@ -18,15 +18,15 @@
 /* jshint esversion:6 */
 
 var _ = require('lodash');
-var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS } = require('../../data/util/constants');
+var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS } = require('../../data/util/constants');
 
 var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
   var classes = _.cloneDeep(bgClasses);
   var defaults = {
-    'very-low': { boundary: 54 },
-    low: { boundary: 70 },
-    target: { boundary: 180 },
-    high: { boundary: 250 },
+    'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
+    low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
+    target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
+    high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
   };
 
   if (bgUnits === MMOLL_UNITS) {

--- a/js/data/util/categorize.js
+++ b/js/data/util/categorize.js
@@ -18,6 +18,7 @@
 /* jshint esversion:6 */
 
 var _ = require('lodash');
+var d3 = require('d3');
 var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS } = require('../../data/util/constants');
 
 var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
@@ -31,7 +32,7 @@ var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
 
   if (bgUnits === MMOLL_UNITS) {
     _.forOwn(defaults, function(value, key) {
-      defaults[key].boundary = Math.round(value.boundary/MGDL_PER_MMOLL);
+      defaults[key].boundary = d3.format('.1f')(value.boundary/MGDL_PER_MMOLL);
     });
   }
 

--- a/js/data/util/categorize.js
+++ b/js/data/util/categorize.js
@@ -31,20 +31,6 @@ var Categorizer = function(bgClasses = {}, bgUnits = MGDL_UNITS){
 
   _.defaults(classes, defaults);
 
-  // mg/dL values are converted to mmol/L and rounded to 5 decimal places on platform.
-  // This can cause some discrepancies when converting back to mg/dL, and throw off the
-  // categorization.
-  // i.e. A 'target' value 180 gets stored as 9.99135, which gets converted back to 180.0000651465
-  // which causes it to be classified as 'high'
-  // Thus, we need to allow for our thresholds accordingly.
-  if (bgUnits === MGDL_UNITS) {
-    var roundingAllowance = 0.0001;
-    classes['very-low'].boundary -= roundingAllowance;
-    classes.low.boundary -= roundingAllowance;
-    classes.target.boundary += roundingAllowance;
-    classes.high.boundary += roundingAllowance;
-  }
-
   return function(d) {
     if (d.value < classes['very-low'].boundary) {
       return 'verylow';

--- a/js/data/util/categorize.js
+++ b/js/data/util/categorize.js
@@ -18,7 +18,6 @@
 /* jshint esversion:6 */
 
 var _ = require('lodash');
-var d3 = require('d3');
 var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS } = require('../../data/util/constants');
 
 var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
@@ -32,7 +31,7 @@ var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
 
   if (bgUnits === MMOLL_UNITS) {
     _.forOwn(defaults, function(value, key) {
-      defaults[key].boundary = d3.format('d')(value.boundary/MGDL_PER_MMOLL);
+      defaults[key].boundary = Math.round(value.boundary/MGDL_PER_MMOLL);
     });
   }
 

--- a/js/data/util/categorize.js
+++ b/js/data/util/categorize.js
@@ -24,17 +24,11 @@ var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS } = require('..
 var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
   var classes = _.cloneDeep(bgClasses);
   var defaults = {
-    'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
-    low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
-    target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
-    high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
+    'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
+    low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
+    target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
+    high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
   };
-
-  if (bgUnits === MMOLL_UNITS) {
-    _.forOwn(defaults, function(value, key) {
-      defaults[key].boundary = d3.format('.1f')(value.boundary/MGDL_PER_MMOLL);
-    });
-  }
 
   _.defaults(classes, defaults);
 

--- a/js/data/util/categorize.js
+++ b/js/data/util/categorize.js
@@ -32,7 +32,7 @@ var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
 
   if (bgUnits === MMOLL_UNITS) {
     _.forOwn(defaults, function(value, key) {
-      defaults[key].boundary = d3.format('.0f')(value.boundary/MGDL_PER_MMOLL);
+      defaults[key].boundary = d3.format('.f')(value.boundary/MGDL_PER_MMOLL);
     });
   }
 

--- a/js/data/util/categorize.js
+++ b/js/data/util/categorize.js
@@ -18,7 +18,7 @@
 /* jshint esversion:6 */
 
 var _ = require('lodash');
-var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS } = require('../../data/util/constants');
+var { MGDL_UNITS, DEFAULT_BG_BOUNDS } = require('../../data/util/constants');
 
 var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
   var classes = _.cloneDeep(bgClasses);

--- a/js/data/util/categorize.js
+++ b/js/data/util/categorize.js
@@ -31,6 +31,20 @@ var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
 
   _.defaults(classes, defaults);
 
+  // mg/dL values are converted to mmol/L and rounded to 5 decimal places on platform.
+  // This can cause some discrepancies when converting back to mg/dL, and throw off the
+  // categorization.
+  // i.e. A 'target' value 180 gets stored as 9.99135, which gets converted back to 180.0000651465
+  // which causes it to be classified as 'high'
+  // Thus, we need to allow for our thresholds accordingly.
+  if (bgUnits === MGDL_UNITS) {
+    var roundingAllowance = 0.0001;
+    classes['very-low'].boundary -= roundingAllowance;
+    classes.low.boundary -= roundingAllowance;
+    classes.target.boundary += roundingAllowance;
+    classes.high.boundary += roundingAllowance;
+  }
+
   return function(d) {
     if (d.value < classes['very-low'].boundary) {
       return 'verylow';

--- a/js/data/util/categorize.js
+++ b/js/data/util/categorize.js
@@ -18,7 +18,6 @@
 /* jshint esversion:6 */
 
 var _ = require('lodash');
-var d3 = require('d3');
 var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS } = require('../../data/util/constants');
 
 var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){

--- a/js/data/util/categorize.js
+++ b/js/data/util/categorize.js
@@ -23,10 +23,10 @@ var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS } = require('../../data/util/const
 var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
   var classes = _.cloneDeep(bgClasses);
   var defaults = {
-    'very-low': { boundary: 55 },
+    'very-low': { boundary: 54 },
     low: { boundary: 70 },
     target: { boundary: 180 },
-    high: { boundary: 300 },
+    high: { boundary: 250 },
   };
 
   if (bgUnits === MMOLL_UNITS) {

--- a/js/data/util/categorize.js
+++ b/js/data/util/categorize.js
@@ -20,7 +20,7 @@
 var _ = require('lodash');
 var { MGDL_UNITS, DEFAULT_BG_BOUNDS } = require('../../data/util/constants');
 
-var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
+var Categorizer = function(bgClasses = {}, bgUnits = MGDL_UNITS){
   var classes = _.cloneDeep(bgClasses);
   var defaults = {
     'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },

--- a/js/data/util/categorize.js
+++ b/js/data/util/categorize.js
@@ -18,6 +18,7 @@
 /* jshint esversion:6 */
 
 var _ = require('lodash');
+var d3 = require('d3');
 var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS } = require('../../data/util/constants');
 
 var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
@@ -31,7 +32,7 @@ var Categorizer = function(bgClasses, bgUnits = MGDL_UNITS){
 
   if (bgUnits === MMOLL_UNITS) {
     _.forOwn(defaults, function(value, key) {
-      defaults[key].boundary = value.boundary/MGDL_PER_MMOLL;
+      defaults[key].boundary = d3.format('.0f')(value.boundary/MGDL_PER_MMOLL);
     });
   }
 

--- a/js/data/util/constants.js
+++ b/js/data/util/constants.js
@@ -2,6 +2,7 @@
 
 const MGDL_UNITS = 'mg/dL';
 const MMOLL_UNITS = 'mmol/L';
+const MGDL_PER_MMOLL = 18.01559;
 
 module.exports = {
   MGDL_PER_MMOLL: 18.01559,

--- a/js/data/util/constants.js
+++ b/js/data/util/constants.js
@@ -1,3 +1,6 @@
+const MGDL_UNITS = 'mg/dL';
+const MMOLL_UNITS = 'mmol/L';
+
 module.exports = {
   MGDL_PER_MMOLL: 18.01559,
   MGDL_UNITS: 'mg/dL',

--- a/js/data/util/constants.js
+++ b/js/data/util/constants.js
@@ -3,10 +3,18 @@ module.exports = {
   MGDL_UNITS: 'mg/dL',
   MMOLL_UNITS: 'mmol/L',
   DEFAULT_BG_BOUNDS: {
-  	veryLow: 54,
-  	targetLower: 70,
-  	targetUpper: 180,
-  	veryHigh:250,
+  	[MGDL_UNITS]:{
+  		veryLow: 54,
+  		targetLower: 70,
+  		targetUpper: 180,
+  		veryHigh:250,
+  	},
+  	[MMOLL_UNITS]: {
+  		veryLow: 3.0,
+     	targetLower: 3.9,
+      	targetUpper: 10.0,
+      	veryHigh: 13.9,
+  	},
   },
   BG_CLAMP_THRESHOLD: 600,
 };

--- a/js/data/util/constants.js
+++ b/js/data/util/constants.js
@@ -1,3 +1,5 @@
+/* jshint esversion:6 */
+
 const MGDL_UNITS = 'mg/dL';
 const MMOLL_UNITS = 'mmol/L';
 

--- a/js/data/util/constants.js
+++ b/js/data/util/constants.js
@@ -21,5 +21,8 @@ module.exports = {
       	veryHigh: 13.9,
   	},
   },
-  BG_CLAMP_THRESHOLD: 600,
+  BG_CLAMP_THRESHOLD: {
+  	[MGDL_UNITS]: 600,
+  	[MMOLL_UNITS]: 600/MGDL_PER_MMOLL,
+  }''
 };

--- a/js/data/util/constants.js
+++ b/js/data/util/constants.js
@@ -2,4 +2,11 @@ module.exports = {
   MGDL_PER_MMOLL: 18.01559,
   MGDL_UNITS: 'mg/dL',
   MMOLL_UNITS: 'mmol/L',
+  DEFAULT_BG_BOUNDS: {
+  	veryLow: 54,
+  	targetLower: 70,
+  	targetUpper: 180,
+  	veryHigh:250,
+  },
+  BG_CLAMP_THRESHOLD: 600,
 };

--- a/js/data/util/constants.js
+++ b/js/data/util/constants.js
@@ -5,25 +5,25 @@ const MMOLL_UNITS = 'mmol/L';
 const MGDL_PER_MMOLL = 18.01559;
 
 module.exports = {
-  MGDL_PER_MMOLL: 18.01559,
-  MGDL_UNITS: 'mg/dL',
-  MMOLL_UNITS: 'mmol/L',
+  MGDL_PER_MMOLL,
+  MGDL_UNITS,
+  MMOLL_UNITS,
   DEFAULT_BG_BOUNDS: {
-  	[MGDL_UNITS]:{
-  		veryLow: 54,
-  		targetLower: 70,
-  		targetUpper: 180,
-  		veryHigh:250,
-  	},
-  	[MMOLL_UNITS]: {
-  		veryLow: 3.0,
-     	targetLower: 3.9,
-      	targetUpper: 10.0,
-      	veryHigh: 13.9,
-  	},
+    [MGDL_UNITS]: {
+      veryLow: 54,
+      targetLower: 70,
+      targetUpper: 180,
+      veryHigh:250,
+    },
+    [MMOLL_UNITS]: {
+      veryLow: 3.0,
+      targetLower: 3.9,
+      targetUpper: 10.0,
+      veryHigh: 13.9,
+    },
   },
   BG_CLAMP_THRESHOLD: {
-  	[MGDL_UNITS]: 600,
-  	[MMOLL_UNITS]: 600/MGDL_PER_MMOLL,
+    [MGDL_UNITS]: 600,
+    [MMOLL_UNITS]: 600/MGDL_PER_MMOLL,
   },
 };

--- a/js/data/util/constants.js
+++ b/js/data/util/constants.js
@@ -24,5 +24,5 @@ module.exports = {
   BG_CLAMP_THRESHOLD: {
   	[MGDL_UNITS]: 600,
   	[MMOLL_UNITS]: 600/MGDL_PER_MMOLL,
-  }''
+  },
 };

--- a/js/plot/cbg.js
+++ b/js/plot/cbg.js
@@ -33,9 +33,9 @@ module.exports = function(pool, opts) {
   var defaults = {
     bgUnits: MGDL_UNITS,
     classes: {
-      low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
-      target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
-      high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
+      low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
     },
     radius: 2.5,
   };

--- a/js/plot/cbg.js
+++ b/js/plot/cbg.js
@@ -94,7 +94,6 @@ module.exports = function(pool, opts) {
       // tooltips
       selection.selectAll('.d3-circle-cbg').on('mouseover', function() {
         var thisCbg = _.clone(d3.select(this).datum());
-        thisCbg.value = format.tooltipBG(thisCbg, opts.bgUnits);
         cbg.addTooltip(thisCbg);
       });
       selection.selectAll('.d3-circle-cbg').on('mouseout', function() {
@@ -126,6 +125,8 @@ module.exports = function(pool, opts) {
     var getBgBoundaryClass = bgBoundaryClass(opts.classes, opts.bgUnits);
     var cssClass = getBgBoundaryClass(d);
     var category = categorize(d);
+    // Round the value after categorization
+    d.value = format.tooltipBG(d, opts.bgUnits);
     tooltips.addFixedTooltip({
       cssClass: cssClass,
       datum: d,

--- a/js/plot/cbg.js
+++ b/js/plot/cbg.js
@@ -33,9 +33,9 @@ module.exports = function(pool, opts) {
   var defaults = {
     bgUnits: MGDL_UNITS,
     classes: {
-      low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
-      target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
-      high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
+      low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
     },
     radius: 2.5,
   };

--- a/js/plot/cbg.js
+++ b/js/plot/cbg.js
@@ -24,7 +24,7 @@ var log = require('bows')('CBG');
 var bgBoundaryClass = require('./util/bgboundary');
 var format = require('../data/util/format');
 var categorizer = require('../../js/data/util/categorize');
-var { MGDL_UNITS } = require('../../js/data/util/constants');
+var { MGDL_UNITS, DEFAULT_BG_BOUNDS } = require('../../js/data/util/constants');
 
 module.exports = function(pool, opts) {
 
@@ -33,9 +33,9 @@ module.exports = function(pool, opts) {
   var defaults = {
     bgUnits: MGDL_UNITS,
     classes: {
-      low: { boundary: 70 },
-      target: { boundary: 180 },
-      high: { boundary: 180 },
+      low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
     },
     radius: 2.5,
   };

--- a/js/plot/cbg.js
+++ b/js/plot/cbg.js
@@ -35,7 +35,7 @@ module.exports = function(pool, opts) {
     classes: {
       low: { boundary: 70 },
       target: { boundary: 180 },
-      high: { boundary: 300 },
+      high: { boundary: 180 },
     },
     radius: 2.5,
   };

--- a/js/plot/smbg.js
+++ b/js/plot/smbg.js
@@ -32,10 +32,10 @@ module.exports = function(pool, opts) {
   var defaults = {
     bgUnits: MGDL_UNITS,
     classes: {
-      'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
-      low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
-      target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
-      high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
     },
     size: 16,
     timezoneAware: false,

--- a/js/plot/smbg.js
+++ b/js/plot/smbg.js
@@ -32,10 +32,10 @@ module.exports = function(pool, opts) {
   var defaults = {
     bgUnits: MGDL_UNITS,
     classes: {
-      'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
-      low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
-      target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
-      high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
     },
     size: 16,
     timezoneAware: false,

--- a/js/plot/smbg.js
+++ b/js/plot/smbg.js
@@ -24,7 +24,7 @@ var log = require('bows')('SMBG');
 var format = require('../data/util/format');
 var scales = require('./util/scales')();
 var bgBoundaryClass = require('./util/bgboundary');
-var { MGDL_UNITS } = require('../data/util/constants');
+var { MGDL_UNITS, DEFAULT_BG_BOUNDS } = require('../data/util/constants');
 
 module.exports = function(pool, opts) {
   opts = opts || {};
@@ -32,10 +32,10 @@ module.exports = function(pool, opts) {
   var defaults = {
     bgUnits: MGDL_UNITS,
     classes: {
-      'very-low': { boundary: 54 },
-      low: { boundary: 70 },
-      target: { boundary: 180 },
-      high: { boundary: 250 },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
     },
     size: 16,
     timezoneAware: false,

--- a/js/plot/smbg.js
+++ b/js/plot/smbg.js
@@ -32,10 +32,10 @@ module.exports = function(pool, opts) {
   var defaults = {
     bgUnits: MGDL_UNITS,
     classes: {
-      'very-low': { boundary: 55 },
+      'very-low': { boundary: 54 },
       low: { boundary: 70 },
       target: { boundary: 180 },
-      high: { boundary: 300 },
+      high: { boundary: 250 },
     },
     size: 16,
     timezoneAware: false,

--- a/js/plot/smbgtime.js
+++ b/js/plot/smbgtime.js
@@ -36,10 +36,10 @@ function SMBGTime (opts) {
   var defaults = {
     bgUnits: MGDL_UNITS,
     classes: {
-      'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
-      low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
-      target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
-      high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
     },
     size: 16,
     rectWidth: 32,

--- a/js/plot/smbgtime.js
+++ b/js/plot/smbgtime.js
@@ -36,10 +36,10 @@ function SMBGTime (opts) {
   var defaults = {
     bgUnits: MGDL_UNITS,
     classes: {
-      'very-low': { boundary: 55 },
+      'very-low': { boundary: 54 },
       low: { boundary: 70 },
       target: { boundary: 180 },
-      high: { boundary: 300 },
+      high: { boundary: 250 },
     },
     size: 16,
     rectWidth: 32,

--- a/js/plot/smbgtime.js
+++ b/js/plot/smbgtime.js
@@ -24,7 +24,7 @@ var log = require('bows')('Two-Week SMBG');
 var dt = require('../data/util/datetime');
 var format = require('../data/util/format');
 var bgBoundaryClass = require('./util/bgboundary');
-var { MGDL_UNITS } = require('../data/util/constants');
+var { MGDL_UNITS, DEFAULT_BG_BOUNDS } = require('../data/util/constants');
 
 function SMBGTime (opts) {
   var MS_IN_HOUR = 3600000;
@@ -36,10 +36,10 @@ function SMBGTime (opts) {
   var defaults = {
     bgUnits: MGDL_UNITS,
     classes: {
-      'very-low': { boundary: 54 },
-      low: { boundary: 70 },
-      target: { boundary: 180 },
-      high: { boundary: 250 },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
     },
     size: 16,
     rectWidth: 32,

--- a/js/plot/smbgtime.js
+++ b/js/plot/smbgtime.js
@@ -36,10 +36,10 @@ function SMBGTime (opts) {
   var defaults = {
     bgUnits: MGDL_UNITS,
     classes: {
-      'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
-      low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
-      target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
-      high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
     },
     size: 16,
     rectWidth: 32,

--- a/js/plot/stats/widget.js
+++ b/js/plot/stats/widget.js
@@ -95,8 +95,8 @@ module.exports = function(pool, opts) {
     });
 
     var pw = opts.puddleWeights;
-    var lowBound = opts.bgUnits === MGDL_UNITS ? opts.classes.low.boundary : opts.classes.low.boundary.toFixed(1);
-    var highBound = opts.bgUnits === MGDL_UNITS ? opts.classes.target.boundary : opts.classes.target.boundary.toFixed(1);
+    var lowBound = format.tooltipBGValue(opts.classes.low.boundary, opts.bgUnits);
+    var highBound = format.tooltipBGValue(opts.classes.target.boundary, opts.bgUnits);
     var targetRangeString = 'Target range: ' + lowBound + ' - ' + highBound + ' ';
 
     // create basal-to-bolus ratio puddle

--- a/js/plot/stats/widget.js
+++ b/js/plot/stats/widget.js
@@ -26,7 +26,7 @@ var dt = require('../../data/util/datetime');
 var format = require('../../data/util/format');
 var Puddle = require('./puddle');
 var bgBoundaryClass = require('../util/bgboundary');
-var { MGDL_UNITS } = require('../../data/util/constants');
+var { MGDL_UNITS, DEFAULT_BG_BOUNDS, BG_CLAMP_THRESHOLD } = require('../../data/util/constants');
 
 module.exports = function(pool, opts) {
 
@@ -36,11 +36,11 @@ module.exports = function(pool, opts) {
 
   var defaults = {
     classes: {
-      'very-low': { boundary: 54 },
-      low: { boundary: 70 },
-      target: { boundary: 180 },
-      high: { boundary: 250 },
-      'very-high': { boundary: 600 },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
+      'very-high': { boundary: BG_CLAMP_THRESHOLD },
     },
     twoWeekOptions: {
       exclusionThreshold: 7

--- a/js/plot/stats/widget.js
+++ b/js/plot/stats/widget.js
@@ -36,10 +36,10 @@ module.exports = function(pool, opts) {
 
   var defaults = {
     classes: {
-      'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
-      low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
-      target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
-      high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
       'very-high': { boundary: BG_CLAMP_THRESHOLD },
     },
     twoWeekOptions: {

--- a/js/plot/stats/widget.js
+++ b/js/plot/stats/widget.js
@@ -40,7 +40,7 @@ module.exports = function(pool, opts) {
       low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
       target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
       high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
-      'very-high': { boundary: BG_CLAMP_THRESHOLD },
+      'very-high': { boundary: BG_CLAMP_THRESHOLD[MGDL_UNITS] },
     },
     twoWeekOptions: {
       exclusionThreshold: 7

--- a/js/plot/stats/widget.js
+++ b/js/plot/stats/widget.js
@@ -36,10 +36,10 @@ module.exports = function(pool, opts) {
 
   var defaults = {
     classes: {
-      'very-low': { boundary: 55 },
+      'very-low': { boundary: 54 },
       low: { boundary: 70 },
       target: { boundary: 180 },
-      high: { boundary: 300 },
+      high: { boundary: 250 },
       'very-high': { boundary: 600 },
     },
     twoWeekOptions: {

--- a/js/plot/stats/widget.js
+++ b/js/plot/stats/widget.js
@@ -36,10 +36,10 @@ module.exports = function(pool, opts) {
 
   var defaults = {
     classes: {
-      'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
-      low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
-      target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
-      high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
       'very-high': { boundary: BG_CLAMP_THRESHOLD },
     },
     twoWeekOptions: {

--- a/js/plot/util/scales.js
+++ b/js/plot/util/scales.js
@@ -21,17 +21,19 @@ var d3 = require('d3');
 var _ = require('lodash');
 
 var commonbolus = require('./commonbolus');
-var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS } = require('../../data/util/constants');
+var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS } = require('../../data/util/constants');
 
 var scales = function(opts) {
   opts = _.assign({}, opts) || {};
 
+  var bgUnits = opts.bgUnits || MGDL_UNITS;
+
   var defaults = {
-    bgUnits: MGDL_UNITS,
+    bgUnits,
     bolusRatio: 0.35,
     MIN_CBG: 39,
     MAX_CBG: 401,
-    TARGET_BG_BOUNDARY: 180,
+    TARGET_BG_BOUNDARY: DEFAULT_BG_BOUNDS[bgUnits].targetUpper,
     carbRadius: 14
   };
   _.defaults(opts, defaults);
@@ -39,7 +41,6 @@ var scales = function(opts) {
   if (opts.bgUnits === MMOLL_UNITS) {
     opts.MIN_CBG = opts.MIN_CBG/MGDL_PER_MMOLL;
     opts.MAX_CBG = opts.MAX_CBG/MGDL_PER_MMOLL;
-    opts.TARGET_BG_BOUNDARY = opts.TARGET_BG_BOUNDARY/MGDL_PER_MMOLL;
   }
 
   return {

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -38,6 +38,7 @@ function TidelineData(data, opts) {
   var REQUIRED_TYPES = ['basal', 'bolus', 'wizard', 'cbg', 'message', 'smbg', 'pumpSettings'];
 
   opts = opts || {};
+  var bgUnits = opts.bgUnits || MGDL_UNITS;
   var defaults = {
     CBG_PERCENT_FOR_ENOUGH: 0.75,
     CBG_MAX_DAILY: 288,
@@ -76,8 +77,6 @@ function TidelineData(data, opts) {
       timezoneName: dt.getBrowserTimezone(),
     }
   };
-
-  var bgUnits = opts.bgUnits || MGDL_UNITS;
 
   _.defaultsDeep(opts, defaults);
   var that = this;

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -34,8 +34,6 @@ var log = __DEV__ ? require('bows')('TidelineData') : _.noop;
 var startTimer = __DEV__ ? function(name) { console.time(name); } : _.noop;
 var endTimer = __DEV__ ? function(name) { console.timeEnd(name); } : _.noop;
 
-var bgUnits = opts.bgUnits || MGDL_UNITS;
-
 function TidelineData(data, opts) {
   var REQUIRED_TYPES = ['basal', 'bolus', 'wizard', 'cbg', 'message', 'smbg', 'pumpSettings'];
 
@@ -78,6 +76,8 @@ function TidelineData(data, opts) {
       timezoneName: dt.getBrowserTimezone(),
     }
   };
+
+  var bgUnits = opts.bgUnits || MGDL_UNITS;
 
   _.defaultsDeep(opts, defaults);
   var that = this;

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -49,6 +49,7 @@ function TidelineData(data, opts) {
       low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
       target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
       high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
+      'very-high': { boundary: BG_CLAMP_THRESHOLD },
     },
     bgUnits: MGDL_UNITS,
     fillOpts: {

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -79,6 +79,12 @@ function TidelineData(data, opts) {
     }
   };
 
+  if (opts.bgUnits === MMOLL_UNITS) {
+    _.forOwn(defaults.bgClasses, function(value, key) {
+      defaults.bgClasses[key].boundary = value.boundary;
+    });
+  }
+
   _.defaultsDeep(opts, defaults);
   var that = this;
 

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -81,7 +81,7 @@ function TidelineData(data, opts) {
 
   if (opts.bgUnits === MMOLL_UNITS) {
     _.forOwn(defaults.bgClasses, function(value, key) {
-      defaults.bgClasses[key].boundary = value.boundary;
+      defaults.bgClasses[key].boundary = value.boundary[MMOLL_UNITS];
     });
   }
 

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -45,11 +45,10 @@ function TidelineData(data, opts) {
     SMBG_DAILY_MIN: 4,
     basicsTypes: ['basal', 'bolus', 'cbg', 'smbg', 'deviceEvent', 'wizard', 'upload'],
     bgClasses: {
-      'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
-      low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
-      target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
-      high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
-      'very-high': { boundary: BG_CLAMP_THRESHOLD }
+      'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
     },
     bgUnits: MGDL_UNITS,
     fillOpts: {
@@ -77,12 +76,6 @@ function TidelineData(data, opts) {
       timezoneName: dt.getBrowserTimezone(),
     }
   };
-
-  if (opts.bgUnits === MMOLL_UNITS) {
-    _.forOwn(defaults.bgClasses, function(value, key) {
-      defaults.bgClasses[key].boundary = value.boundary/MGDL_PER_MMOLL;
-    });
-  }
 
   _.defaultsDeep(opts, defaults);
   var that = this;

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -28,7 +28,7 @@ var BasalUtil = require('./data/basalutil');
 var BolusUtil = require('./data/bolusutil');
 var BGUtil = require('./data/bgutil');
 var dt = require('./data/util/datetime');
-var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS, BG_CLAMP_THRESHOLD } = require('./data/util/constants');
+var { MGDL_UNITS, DEFAULT_BG_BOUNDS, BG_CLAMP_THRESHOLD } = require('./data/util/constants');
 
 var log = __DEV__ ? require('bows')('TidelineData') : _.noop;
 var startTimer = __DEV__ ? function(name) { console.time(name); } : _.noop;

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -45,11 +45,11 @@ function TidelineData(data, opts) {
     SMBG_DAILY_MIN: 4,
     basicsTypes: ['basal', 'bolus', 'cbg', 'smbg', 'deviceEvent', 'wizard', 'upload'],
     bgClasses: {
-      'very-low': { boundary: 55 },
+      'very-low': { boundary: 54 },
       low: { boundary: 70 },
       target: { boundary: 180 },
-      high: { boundary: 300 },
-      'very-high': { boundary: 600 }
+      high: { boundary: 250 },
+      'very-high': { boundary: 250 }
     },
     bgUnits: MGDL_UNITS,
     fillOpts: {

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -368,8 +368,22 @@ function TidelineData(data, opts) {
 
   this.setBGPrefs = function() {
     startTimer('setBGPrefs');
-    this.bgClasses = opts.bgClasses;
-    this.bgUnits = opts.bgUnits;
+      this.bgClasses = opts.bgClasses;
+      this.bgUnits = opts.bgUnits;
+
+      // mg/dL values are converted to mmol/L and rounded to 5 decimal places on platform.
+      // This can cause some discrepancies when converting back to mg/dL, and throw off the
+      // categorization.
+      // i.e. A 'target' value 180 gets stored as 9.99135, which gets converted back to 180.0000651465
+      // which causes it to be classified as 'high'
+      // Thus, we need to allow for our thresholds accordingly.
+      if (this.bgUnits === MGDL_UNITS) {
+        var roundingAllowance = 0.0001;
+        this.bgClasses['very-low'].boundary -= roundingAllowance;
+        this.bgClasses.low.boundary -= roundingAllowance;
+        this.bgClasses.target.boundary += roundingAllowance;
+        this.bgClasses.high.boundary += roundingAllowance;
+      }
     endTimer('setBGPrefs');
   };
 

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -34,7 +34,7 @@ var log = __DEV__ ? require('bows')('TidelineData') : _.noop;
 var startTimer = __DEV__ ? function(name) { console.time(name); } : _.noop;
 var endTimer = __DEV__ ? function(name) { console.timeEnd(name); } : _.noop;
 
-var bgUnits = MGDL_UNITS
+var bgUnits = MGDL_UNITS;
 
 function TidelineData(data, opts) {
   var REQUIRED_TYPES = ['basal', 'bolus', 'wizard', 'cbg', 'message', 'smbg', 'pumpSettings'];
@@ -51,7 +51,7 @@ function TidelineData(data, opts) {
       low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
       target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
       high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
-      'very-high': { boundary: BG_CLAMP_THRESHOLD },
+      'very-high': { boundary: BG_CLAMP_THRESHOLD[bgUnits] },
     },
     fillOpts: {
       classes: {

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -45,10 +45,10 @@ function TidelineData(data, opts) {
     SMBG_DAILY_MIN: 4,
     basicsTypes: ['basal', 'bolus', 'cbg', 'smbg', 'deviceEvent', 'wizard', 'upload'],
     bgClasses: {
-      'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
-      low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
-      target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
-      high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
     },
     bgUnits: MGDL_UNITS,
     fillOpts: {

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -34,7 +34,7 @@ var log = __DEV__ ? require('bows')('TidelineData') : _.noop;
 var startTimer = __DEV__ ? function(name) { console.time(name); } : _.noop;
 var endTimer = __DEV__ ? function(name) { console.timeEnd(name); } : _.noop;
 
-var bgUnits = MGDL_UNITS;
+var bgUnits = opts.bgUnits || MGDL_UNITS;
 
 function TidelineData(data, opts) {
   var REQUIRED_TYPES = ['basal', 'bolus', 'wizard', 'cbg', 'message', 'smbg', 'pumpSettings'];
@@ -45,7 +45,7 @@ function TidelineData(data, opts) {
     CBG_MAX_DAILY: 288,
     SMBG_DAILY_MIN: 4,
     basicsTypes: ['basal', 'bolus', 'cbg', 'smbg', 'deviceEvent', 'wizard', 'upload'],
-    bgUnits: MGDL_UNITS,
+    bgUnits,
     bgClasses: {
       'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
       low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
@@ -78,12 +78,6 @@ function TidelineData(data, opts) {
       timezoneName: dt.getBrowserTimezone(),
     }
   };
-
-  if (opts.bgUnits === MMOLL_UNITS) {
-    _.forOwn(defaults.bgClasses, function(value, key) {
-      defaults.bgClasses[key].boundary = value.boundary[MMOLL_UNITS];
-    });
-  }
 
   _.defaultsDeep(opts, defaults);
   var that = this;

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -49,7 +49,7 @@ function TidelineData(data, opts) {
       low: { boundary: 70 },
       target: { boundary: 180 },
       high: { boundary: 250 },
-      'very-high': { boundary: 250 }
+      'very-high': { boundary: 600 }
     },
     bgUnits: MGDL_UNITS,
     fillOpts: {

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -28,7 +28,7 @@ var BasalUtil = require('./data/basalutil');
 var BolusUtil = require('./data/bolusutil');
 var BGUtil = require('./data/bgutil');
 var dt = require('./data/util/datetime');
-var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS } = require('./data/util/constants');
+var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS, BG_CLAMP_THRESHOLD } = require('./data/util/constants');
 
 var log = __DEV__ ? require('bows')('TidelineData') : _.noop;
 var startTimer = __DEV__ ? function(name) { console.time(name); } : _.noop;
@@ -45,11 +45,11 @@ function TidelineData(data, opts) {
     SMBG_DAILY_MIN: 4,
     basicsTypes: ['basal', 'bolus', 'cbg', 'smbg', 'deviceEvent', 'wizard', 'upload'],
     bgClasses: {
-      'very-low': { boundary: 54 },
-      low: { boundary: 70 },
-      target: { boundary: 180 },
-      high: { boundary: 250 },
-      'very-high': { boundary: 600 }
+      'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
+      'very-high': { boundary: BG_CLAMP_THRESHOLD }
     },
     bgUnits: MGDL_UNITS,
     fillOpts: {

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -38,7 +38,7 @@ function TidelineData(data, opts) {
   var REQUIRED_TYPES = ['basal', 'bolus', 'wizard', 'cbg', 'message', 'smbg', 'pumpSettings'];
 
   opts = opts || {};
-
+  bgUnits = MGDL_UNITS;
   var defaults = {
     CBG_PERCENT_FOR_ENOUGH: 0.75,
     CBG_MAX_DAILY: 288,

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -44,14 +44,14 @@ function TidelineData(data, opts) {
     CBG_MAX_DAILY: 288,
     SMBG_DAILY_MIN: 4,
     basicsTypes: ['basal', 'bolus', 'cbg', 'smbg', 'deviceEvent', 'wizard', 'upload'],
+    bgUnits: MGDL_UNITS,
     bgClasses: {
-      'very-low': { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow },
-      low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
-      target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
-      high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
+      'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
+      low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
+      target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
+      high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
       'very-high': { boundary: BG_CLAMP_THRESHOLD },
     },
-    bgUnits: MGDL_UNITS,
     fillOpts: {
       classes: {
         0: 'darkest',

--- a/js/tidelinedata.js
+++ b/js/tidelinedata.js
@@ -34,11 +34,12 @@ var log = __DEV__ ? require('bows')('TidelineData') : _.noop;
 var startTimer = __DEV__ ? function(name) { console.time(name); } : _.noop;
 var endTimer = __DEV__ ? function(name) { console.timeEnd(name); } : _.noop;
 
+var bgUnits = MGDL_UNITS
+
 function TidelineData(data, opts) {
   var REQUIRED_TYPES = ['basal', 'bolus', 'wizard', 'cbg', 'message', 'smbg', 'pumpSettings'];
 
   opts = opts || {};
-  bgUnits = MGDL_UNITS;
   var defaults = {
     CBG_PERCENT_FOR_ENOUGH: 0.75,
     CBG_MAX_DAILY: 288,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.7.4-standardbgdefaultsfix.3",
+  "version": "0.7.4-standardbgdefaultsfix.4",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.7.4-standardbgdefaultsfix.4",
+  "version": "0.7.4-standardbgdefaultsfix.5",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.7.4-standardbgdefaultsfix.1",
+  "version": "0.7.4-standardbgdefaultsfix.2",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.7.2",
+  "version": "0.7.4-standardbgdefaultsfix.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.7.4-standardbgdefaultsfix.6",
+  "version": "0.7.4-standardbgdefaultsfix.7",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.7.4-standardbgdefaultsfix.2",
+  "version": "0.7.4-standardbgdefaultsfix.3",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.7.4-standardbgdefaultsfix.5",
+  "version": "0.7.4-standardbgdefaultsfix.6",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/modalday/ModalDay.js
+++ b/plugins/blip/modalday/ModalDay.js
@@ -494,7 +494,7 @@ module.exports = {
     opts = opts || {};
     var defaults = {
       baseMargin: opts.baseMargin || 10,
-      bgDomain: [0,BG_CLAMP_THRESHOLD],
+      bgDomain: [0, BG_CLAMP_THRESHOLD[MGDL_UNITS]],
       brushHeight: 0,
       clampTop: false,
       smbg: {

--- a/plugins/blip/modalday/ModalDay.js
+++ b/plugins/blip/modalday/ModalDay.js
@@ -33,7 +33,7 @@ var smbgBox = require('./SMBGBox');
 var smbgDay = require('./SMBGDay');
 var smbgInfo = require('./SMBGInfo');
 
-var { MGDL_UNITS, MMOLL_UNITS } = require('../../../js/data/util/constants');
+var { MGDL_UNITS, MMOLL_UNITS, BG_CLAMP_THRESHOLD } = require('../../../js/data/util/constants');
 
 var THREE_HRS = 10800000;
 var chart;
@@ -494,7 +494,7 @@ module.exports = {
     opts = opts || {};
     var defaults = {
       baseMargin: opts.baseMargin || 10,
-      bgDomain: [0,600],
+      bgDomain: [0,BG_CLAMP_THRESHOLD],
       brushHeight: 0,
       clampTop: false,
       smbg: {

--- a/plugins/nurseshark/index.js
+++ b/plugins/nurseshark/index.js
@@ -28,7 +28,7 @@ var dt = require('../../js/data/util/datetime');
 var log = __DEV__ && !__TEST__ ? require('bows')('Nurseshark') : _.noop;
 
 function translateBg(value) {
-  return Math.round(MGDL_PER_MMOLL * value);
+  return MGDL_PER_MMOLL * value;
 }
 
 function isBadStatus(d) {

--- a/test/blip/components/CalendarContainer.test.js
+++ b/test/blip/components/CalendarContainer.test.js
@@ -28,6 +28,7 @@
 /* global chai */
 
 var expect = chai.expect;
+var { DEFAULT_BG_BOUNDS } = require('../js/data/util/constants');
 
 const React = require('react');
 const _ = require('lodash');
@@ -48,19 +49,19 @@ describe('CalendarContainer', () => {
   var props = {
     bgClasses: {
       'very-low': {
-        boundary: 54,
+        boundary: DEFAULT_BG_BOUNDS.veryLow,
       },
       'low': {
-        boundary: 70,
+        boundary: DEFAULT_BG_BOUNDS.targetLower,
       },
       'target': {
-        boundary: 180,
+        boundary: DEFAULT_BG_BOUNDS.targetUpper,
       },
       'high': {
-        boundary: 180,
+        boundary: DEFAULT_BG_BOUNDS.veryHigh,
       },
       'very-high': {
-        boundary: 250,
+        boundary: 600,
       },
     },
     bgUnits: 'mg/dL',

--- a/test/blip/components/CalendarContainer.test.js
+++ b/test/blip/components/CalendarContainer.test.js
@@ -28,7 +28,7 @@
 /* global chai */
 
 var expect = chai.expect;
-var { DEFAULT_BG_BOUNDS } = require('../../../js/data/util/constants');
+var { DEFAULT_BG_BOUNDS, MGDL_UNITS } = require('../../../js/data/util/constants');
 
 const React = require('react');
 const _ = require('lodash');
@@ -49,16 +49,16 @@ describe('CalendarContainer', () => {
   var props = {
     bgClasses: {
       'very-low': {
-        boundary: DEFAULT_BG_BOUNDS.veryLow,
+        boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow,
       },
       'low': {
-        boundary: DEFAULT_BG_BOUNDS.targetLower,
+        boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower,
       },
       'target': {
-        boundary: DEFAULT_BG_BOUNDS.targetUpper,
+        boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper,
       },
       'high': {
-        boundary: DEFAULT_BG_BOUNDS.veryHigh,
+        boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh,
       },
       'very-high': {
         boundary: 600,

--- a/test/blip/components/CalendarContainer.test.js
+++ b/test/blip/components/CalendarContainer.test.js
@@ -28,7 +28,7 @@
 /* global chai */
 
 var expect = chai.expect;
-var { DEFAULT_BG_BOUNDS } = require('../js/data/util/constants');
+var { DEFAULT_BG_BOUNDS } = require('../../../js/data/util/constants');
 
 const React = require('react');
 const _ = require('lodash');

--- a/test/blip/components/CalendarContainer.test.js
+++ b/test/blip/components/CalendarContainer.test.js
@@ -48,19 +48,19 @@ describe('CalendarContainer', () => {
   var props = {
     bgClasses: {
       'very-low': {
-        boundary: 60,
+        boundary: 54,
       },
       'low': {
-        boundary: 80,
+        boundary: 70,
       },
       'target': {
         boundary: 180,
       },
       'high': {
-        boundary: 200,
+        boundary: 180,
       },
       'very-high': {
-        boundary: 300,
+        boundary: 250,
       },
     },
     bgUnits: 'mg/dL',

--- a/test/blip/components/CalendarContainer.test.js
+++ b/test/blip/components/CalendarContainer.test.js
@@ -28,7 +28,7 @@
 /* global chai */
 
 var expect = chai.expect;
-var { DEFAULT_BG_BOUNDS, MGDL_UNITS } = require('../../../js/data/util/constants');
+var { DEFAULT_BG_BOUNDS, MGDL_UNITS, BG_CLAMP_THRESHOLD } = require('../../../js/data/util/constants');
 
 const React = require('react');
 const _ = require('lodash');
@@ -61,7 +61,7 @@ describe('CalendarContainer', () => {
         boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh,
       },
       'very-high': {
-        boundary: 600,
+        boundary: BG_CLAMP_THRESHOLD[MGDL_UNITS],
       },
     },
     bgUnits: 'mg/dL',

--- a/test/blip/components/chart/BGDistribution.test.js
+++ b/test/blip/components/chart/BGDistribution.test.js
@@ -25,6 +25,7 @@
 /* global chai */
 
 var expect = chai.expect;
+var { DEFAULT_BG_BOUNDS } = require('../js/data/util/constants');
 
 const React = require('react');
 const _ = require('lodash');
@@ -54,19 +55,19 @@ describe('BGDistribution', () => {
   var props = {
     bgClasses: {
       'very-low': {
-        boundary: 54,
+        boundary: DEFAULT_BG_BOUNDS.veryLow,
       },
       'low': {
-        boundary: 70,
+        boundary: DEFAULT_BG_BOUNDS.targetLower,
       },
       'target': {
-        boundary: 180,
+        boundary: DEFAULT_BG_BOUNDS.targetUpper,
       },
       'high': {
-        boundary: 180,
+        boundary: DEFAULT_BG_BOUNDS.veryHigh,
       },
       'very-high': {
-        boundary: 250,
+        boundary: 600,
       },
     },
     bgUnits: 'mg/dL',

--- a/test/blip/components/chart/BGDistribution.test.js
+++ b/test/blip/components/chart/BGDistribution.test.js
@@ -25,7 +25,7 @@
 /* global chai */
 
 var expect = chai.expect;
-var { DEFAULT_BG_BOUNDS } = require('../js/data/util/constants');
+var { DEFAULT_BG_BOUNDS } = require('../../../../js/data/util/constants');
 
 const React = require('react');
 const _ = require('lodash');

--- a/test/blip/components/chart/BGDistribution.test.js
+++ b/test/blip/components/chart/BGDistribution.test.js
@@ -25,7 +25,7 @@
 /* global chai */
 
 var expect = chai.expect;
-var { DEFAULT_BG_BOUNDS } = require('../../../../js/data/util/constants');
+var { DEFAULT_BG_BOUNDS, MGDL_UNITS } = require('../../../../js/data/util/constants');
 
 const React = require('react');
 const _ = require('lodash');
@@ -55,16 +55,16 @@ describe('BGDistribution', () => {
   var props = {
     bgClasses: {
       'very-low': {
-        boundary: DEFAULT_BG_BOUNDS.veryLow,
+        boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow,
       },
       'low': {
-        boundary: DEFAULT_BG_BOUNDS.targetLower,
+        boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower,
       },
       'target': {
-        boundary: DEFAULT_BG_BOUNDS.targetUpper,
+        boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper,
       },
       'high': {
-        boundary: DEFAULT_BG_BOUNDS.veryHigh,
+        boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh,
       },
       'very-high': {
         boundary: 600,

--- a/test/blip/components/chart/BGDistribution.test.js
+++ b/test/blip/components/chart/BGDistribution.test.js
@@ -54,19 +54,19 @@ describe('BGDistribution', () => {
   var props = {
     bgClasses: {
       'very-low': {
-        boundary: 60,
+        boundary: 54,
       },
       'low': {
-        boundary: 80,
+        boundary: 70,
       },
       'target': {
         boundary: 180,
       },
       'high': {
-        boundary: 200,
+        boundary: 180,
       },
       'very-high': {
-        boundary: 300,
+        boundary: 250,
       },
     },
     bgUnits: 'mg/dL',

--- a/test/blip/components/misc/SummaryGroup.test.js
+++ b/test/blip/components/misc/SummaryGroup.test.js
@@ -45,19 +45,19 @@ describe('SummaryGroup', () => {
   var props = {
     bgClasses: {
       'very-low': {
-        boundary: 60,
+        boundary: 54,
       },
       'low': {
-        boundary: 80,
+        boundary: 70,
       },
       'target': {
         boundary: 180,
       },
       'high': {
-        boundary: 200,
+        boundary: 180,
       },
       'very-high': {
-        boundary: 300,
+        boundary: 250,
       },
     },
     bgUnits: 'mg/dL',

--- a/test/blip/components/misc/SummaryGroup.test.js
+++ b/test/blip/components/misc/SummaryGroup.test.js
@@ -28,7 +28,7 @@
 /* global chai */
 
 var expect = chai.expect;
-var { DEFAULT_BG_BOUNDS } = require('../js/data/util/constants');
+var { DEFAULT_BG_BOUNDS } = require('../../../../js/data/util/constants');
 
 const React = require('react');
 const _ = require('lodash');

--- a/test/blip/components/misc/SummaryGroup.test.js
+++ b/test/blip/components/misc/SummaryGroup.test.js
@@ -28,7 +28,7 @@
 /* global chai */
 
 var expect = chai.expect;
-var { DEFAULT_BG_BOUNDS } = require('../../../../js/data/util/constants');
+var { DEFAULT_BG_BOUNDS, MGDL_UNITS } = require('../../../../js/data/util/constants');
 
 const React = require('react');
 const _ = require('lodash');
@@ -46,16 +46,16 @@ describe('SummaryGroup', () => {
   var props = {
     bgClasses: {
       'very-low': {
-        boundary: DEFAULT_BG_BOUNDS.veryLow,
+        boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow,
       },
       'low': {
-        boundary: DEFAULT_BG_BOUNDS.targetLower,
+        boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower,
       },
       'target': {
-        boundary: DEFAULT_BG_BOUNDS.targetUpper,
+        boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper,
       },
       'high': {
-        boundary: DEFAULT_BG_BOUNDS.veryHigh,
+        boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh,
       },
       'very-high': {
         boundary: 600,

--- a/test/blip/components/misc/SummaryGroup.test.js
+++ b/test/blip/components/misc/SummaryGroup.test.js
@@ -28,6 +28,7 @@
 /* global chai */
 
 var expect = chai.expect;
+var { DEFAULT_BG_BOUNDS } = require('../js/data/util/constants');
 
 const React = require('react');
 const _ = require('lodash');
@@ -45,19 +46,19 @@ describe('SummaryGroup', () => {
   var props = {
     bgClasses: {
       'very-low': {
-        boundary: 54,
+        boundary: DEFAULT_BG_BOUNDS.veryLow,
       },
       'low': {
-        boundary: 70,
+        boundary: DEFAULT_BG_BOUNDS.targetLower,
       },
       'target': {
-        boundary: 180,
+        boundary: DEFAULT_BG_BOUNDS.targetUpper,
       },
       'high': {
-        boundary: 180,
+        boundary: DEFAULT_BG_BOUNDS.veryHigh,
       },
       'very-high': {
-        boundary: 250,
+        boundary: 600,
       },
     },
     bgUnits: 'mg/dL',

--- a/test/categorize_test.js
+++ b/test/categorize_test.js
@@ -20,14 +20,14 @@
 var chai = require('chai');
 var assert = chai.assert;
 var expect = chai.expect;
-var { MGDL_PER_MMOLL } = require('../js/data/util/constants');
+var { MGDL_PER_MMOLL, DEFAULT_BG_BOUNDS } = require('../js/data/util/constants');
 
 var categorizer = require('../js/data/util/categorize');
 var defaultBgClasses = {
-  'very-low': { boundary: 54 },
-  low: { boundary: 70 },
-  target: { boundary: 180 },
-  high: { boundary: 250 },
+  'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
+  low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
+  target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
+  high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
 };
 var alternateBgClasses = {
   'very-low': { boundary: 60 },
@@ -36,10 +36,10 @@ var alternateBgClasses = {
   high: { boundary: 250 },
 };
 var mmollBgClasses = {
-  'very-low': { boundary: 54/MGDL_PER_MMOLL },
-  low: { boundary: 70/MGDL_PER_MMOLL },
-  target: { boundary: 180/MGDL_PER_MMOLL },
-  high: { boundary: 250/MGDL_PER_MMOLL },
+  'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow/MGDL_PER_MMOLL },
+  low: { boundary: DEFAULT_BG_BOUNDS.targetLower/MGDL_PER_MMOLL },
+  target: { boundary: DEFAULT_BG_BOUNDS.targetUpper/MGDL_PER_MMOLL },
+  high: { boundary: DEFAULT_BG_BOUNDS.veryHigh/MGDL_PER_MMOLL },
 };
 
 describe('Categorize', function() {
@@ -54,119 +54,107 @@ describe('Categorize', function() {
 
   describe('categorization', function(){
     describe('with default classes', function(){
+      it('should categorize 53 as "verylow"', function(){
+        expect(defaultCategorizer({value:53})).to.equal("verylow");
+      });
       it('should categorize 54 as "low"', function(){
         expect(defaultCategorizer({value:54})).to.equal("low");
       });
-      it('should categorize 55 as "low"', function(){
-        expect(defaultCategorizer({value:55})).to.equal("low");
-      });
-      it('should categorize 60 as "low"', function(){
-        expect(defaultCategorizer({value:60})).to.equal("low");
+      it('should categorize 69 as "low"', function(){
+        expect(defaultCategorizer({value:69})).to.equal("low");
       });
       it('should categorize 70 as "target"', function(){
         expect(defaultCategorizer({value:70})).to.equal("target");
       });
-      it('should categorize 100 as "target"', function(){
-        expect(defaultCategorizer({value:100})).to.equal("target");
-      });
       it('should categorize 180 as "target"', function(){
         expect(defaultCategorizer({value:180})).to.equal("target");
+      });
+      it('should categorize 181 as "high"', function(){
+        expect(defaultCategorizer({value:181})).to.equal("high");
       });
       it('should categorize 250 as "high"', function(){
         expect(defaultCategorizer({value:250})).to.equal("high");
       });
-      it('should categorize 300 as "veryhigh"', function(){
-        expect(defaultCategorizer({value:300})).to.equal("veryhigh");
-      });
-      it('should categorize 350 as "veryhigh"', function(){
-        expect(defaultCategorizer({value:350})).to.equal("veryhigh");
+      it('should categorize 251 as "veryhigh"', function(){
+        expect(defaultCategorizer({value:251})).to.equal("veryhigh");
       });
     });
     describe('with alternate classes', function(){
-      it('should categorize 55 as "verylow"', function(){
-        expect(alternateCategorizer({value:55})).to.equal("verylow");
+      it('should categorize 59 as "verylow"', function(){
+        expect(alternateCategorizer({value:59})).to.equal("verylow");
       });
       it('should categorize 60 as "low"', function(){
         expect(alternateCategorizer({value:60})).to.equal("low");
       });
-      it('should categorize 70 as "low"', function(){
-        expect(alternateCategorizer({value:70})).to.equal("low");
+      it('should categorize 79 as "low"', function(){
+        expect(alternateCategorizer({value:79})).to.equal("low");
       });
       it('should categorize 80 as "target"', function(){
         expect(alternateCategorizer({value:80})).to.equal("target");
       });
-      it('should categorize 100 as "target"', function(){
-        expect(alternateCategorizer({value:100})).to.equal("target");
-      });
       it('should categorize 150 as "target"', function(){
         expect(alternateCategorizer({value:150})).to.equal("target");
       });
-      it('should categorize 220 as "high"', function(){
-        expect(alternateCategorizer({value:220})).to.equal("high");
+      it('should categorize 151 as "high"', function(){
+        expect(alternateCategorizer({value:151})).to.equal("high");
       });
       it('should categorize 250 as "high"', function(){
         expect(alternateCategorizer({value:250})).to.equal("high");
       });
-      it('should categorize 270 as "veryhigh"', function(){
-        expect(alternateCategorizer({value:270})).to.equal("veryhigh");
+      it('should categorize 251 as "veryhigh"', function(){
+        expect(alternateCategorizer({value:251})).to.equal("veryhigh");
       });
     });
     describe('with no classes', function(){
+      it('should categorize 53 as "verylow"', function(){
+        expect(noConfigCategorizer({value:53})).to.equal("verylow");
+      });
       it('should categorize 54 as "low"', function(){
         expect(noConfigCategorizer({value:54})).to.equal("low");
       });
-      it('should categorize 55 as "low"', function(){
-        expect(noConfigCategorizer({value:55})).to.equal("low");
-      });
-      it('should categorize 60 as "low"', function(){
-        expect(noConfigCategorizer({value:60})).to.equal("low");
+      it('should categorize 69 as "low"', function(){
+        expect(noConfigCategorizer({value:69})).to.equal("low");
       });
       it('should categorize 70 as "target"', function(){
         expect(noConfigCategorizer({value:70})).to.equal("target");
       });
-      it('should categorize 100 as "target"', function(){
-        expect(noConfigCategorizer({value:100})).to.equal("target");
-      });
       it('should categorize 180 as "target"', function(){
         expect(noConfigCategorizer({value:180})).to.equal("target");
+      });
+      it('should categorize 181 as "high"', function(){
+        expect(noConfigCategorizer({value:181})).to.equal("high");
       });
       it('should categorize 250 as "high"', function(){
         expect(noConfigCategorizer({value:250})).to.equal("high");
       });
-      it('should categorize 300 as "veryhigh"', function(){
-        expect(noConfigCategorizer({value:300})).to.equal("veryhigh");
-      });
-      it('should categorize 350 as "veryhigh"', function(){
-        expect(noConfigCategorizer({value:350})).to.equal("veryhigh");
+      it('should categorize 251 as "veryhigh"', function(){
+        expect(noConfigCategorizer({value:251})).to.equal("veryhigh");
       });
     });
     describe('with mmoll values', function(){
-      it('should categorize 2.5 as "verylow"', function(){
-        expect(mmollCategorizer({value:2.8})).to.equal("verylow");
+      it('should categorize 2.9 as "verylow"', function(){
+        expect(mmollCategorizer({value:2.9})).to.equal("verylow");
       });
-      it('should categorize 3.2 as "low"', function(){
-        expect(mmollCategorizer({value:3.2})).to.equal("low");
+      it('should categorize 3.0 as "low"', function(){
+        expect(mmollCategorizer({value:3.0})).to.equal("low");
       });
-      it('should categorize 3.7 as "low"', function(){
-        expect(mmollCategorizer({value:3.7})).to.equal("low");
+      it('should categorize 3.8 as "low"', function(){
+        expect(mmollCategorizer({value:3.8})).to.equal("low");
       });
-      it('should categorize 6.5 as "target"', function(){
-        expect(mmollCategorizer({value:6.5})).to.equal("target");
+      it('should categorize 3.9 as "target"', function(){
+        expect(mmollCategorizer({value:3.9})).to.equal("target");
       });
-      it('should categorize 8.0 as "target"', function(){
-        expect(mmollCategorizer({value:8.0})).to.equal("target");
+      it('should categorize 10.0 as "target"', function(){
+        expect(mmollCategorizer({value:10.0})).to.equal("target");
       });
-      it('should categorize 9.9 as "target"', function(){
-        expect(mmollCategorizer({value:9.9})).to.equal("target");
+      it('should categorize 10.1 as "high"', function(){
+        expect(mmollCategorizer({value:10.1})).to.equal("high");
       });
-      it('should categorize 12.2 as "high"', function(){
-        expect(mmollCategorizer({value:12.2})).to.equal("high");
+      it('should categorize 13.9 as "high"', function(){
+        expect(mmollCategorizer({value:13.9})).to.equal("high");
       });
-      it('should categorize 15.8 as "veryhigh"', function(){
-        expect(mmollCategorizer({value:15.8})).to.equal("veryhigh");
-      });
-      it('should categorize 22.0 as "veryhigh"', function(){
-        expect(mmollCategorizer({value:22.0})).to.equal("veryhigh");
+      it('should categorize 14.0 as "veryhigh"', function(){
+        expect(mmollCategorizer({value:14.0})).to.equal("veryhigh");
       });
     });
   });

--- a/test/categorize_test.js
+++ b/test/categorize_test.js
@@ -18,6 +18,7 @@
  /* jshint esversion:6 */
 
 var chai = require('chai');
+var d3 = require('d3');
 var assert = chai.assert;
 var expect = chai.expect;
 var { MGDL_PER_MMOLL, DEFAULT_BG_BOUNDS } = require('../js/data/util/constants');
@@ -36,10 +37,10 @@ var alternateBgClasses = {
   high: { boundary: 250 },
 };
 var mmollBgClasses = {
-  'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow/MGDL_PER_MMOLL },
-  low: { boundary: DEFAULT_BG_BOUNDS.targetLower/MGDL_PER_MMOLL },
-  target: { boundary: DEFAULT_BG_BOUNDS.targetUpper/MGDL_PER_MMOLL },
-  high: { boundary: DEFAULT_BG_BOUNDS.veryHigh/MGDL_PER_MMOLL },
+  'very-low': { boundary: d3.format('.1f')(DEFAULT_BG_BOUNDS.veryLow/MGDL_PER_MMOLL) },
+  low: { boundary: d3.format('.1f')(DEFAULT_BG_BOUNDS.targetLower/MGDL_PER_MMOLL) },
+  target: { boundary: d3.format('.1f')(DEFAULT_BG_BOUNDS.targetUpper/MGDL_PER_MMOLL) },
+  high: { boundary: d3.format('.1f')(DEFAULT_BG_BOUNDS.veryHigh/MGDL_PER_MMOLL) },
 };
 
 describe('Categorize', function() {

--- a/test/categorize_test.js
+++ b/test/categorize_test.js
@@ -133,7 +133,7 @@ describe('Categorize', function() {
       it('should categorize 250 as "high"', function(){
         expect(noConfigCategorizer({value:250})).to.equal("high");
       });
-      it('should categorize 300 as "high"', function(){
+      it('should categorize 300 as "veryhigh"', function(){
         expect(noConfigCategorizer({value:300})).to.equal("high");
       });
       it('should categorize 350 as "veryhigh"', function(){
@@ -144,7 +144,7 @@ describe('Categorize', function() {
       it('should categorize 2.5 as "verylow"', function(){
         expect(mmollCategorizer({value:2.8})).to.equal("verylow");
       });
-      it('should categorize 3.2 as "verylow"', function(){
+      it('should categorize 3.2 as "low"', function(){
         expect(mmollCategorizer({value:3.2})).to.equal("low");
       });
       it('should categorize 3.7 as "low"', function(){

--- a/test/categorize_test.js
+++ b/test/categorize_test.js
@@ -112,8 +112,8 @@ describe('Categorize', function() {
       });
     });
     describe('with no classes', function(){
-      it('should categorize 54 as "verylow"', function(){
-        expect(noConfigCategorizer({value:54})).to.equal("verylow");
+      it('should categorize 54 as "low"', function(){
+        expect(noConfigCategorizer({value:54})).to.equal("low");
       });
       it('should categorize 55 as "low"', function(){
         expect(noConfigCategorizer({value:55})).to.equal("low");

--- a/test/categorize_test.js
+++ b/test/categorize_test.js
@@ -54,8 +54,8 @@ describe('Categorize', function() {
 
   describe('categorization', function(){
     describe('with default classes', function(){
-      it('should categorize 54 as "verylow"', function(){
-        expect(defaultCategorizer({value:54})).to.equal("verylow");
+      it('should categorize 54 as "low"', function(){
+        expect(defaultCategorizer({value:54})).to.equal("low");
       });
       it('should categorize 55 as "low"', function(){
         expect(defaultCategorizer({value:55})).to.equal("low");
@@ -134,7 +134,7 @@ describe('Categorize', function() {
         expect(noConfigCategorizer({value:250})).to.equal("high");
       });
       it('should categorize 300 as "veryhigh"', function(){
-        expect(noConfigCategorizer({value:300})).to.equal("high");
+        expect(noConfigCategorizer({value:300})).to.equal("veryhigh");
       });
       it('should categorize 350 as "veryhigh"', function(){
         expect(noConfigCategorizer({value:350})).to.equal("veryhigh");

--- a/test/categorize_test.js
+++ b/test/categorize_test.js
@@ -18,7 +18,6 @@
  /* jshint esversion:6 */
 
 var chai = require('chai');
-var d3 = require('d3');
 var assert = chai.assert;
 var expect = chai.expect;
 var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS } = require('../js/data/util/constants');

--- a/test/categorize_test.js
+++ b/test/categorize_test.js
@@ -159,14 +159,14 @@ describe('Categorize', function() {
     });
     describe('with mg/dL conversion rounding allowances', function() {
       it('should apply `0.0001` rounding allowances for mg/dL values', function() {
-          expect(defaultCategorizer({value:53.9998})).to.equal("verylow");
-          expect(defaultCategorizer({value:53.9999})).to.equal("low");
-          expect(defaultCategorizer({value:69.9998})).to.equal("low");
-          expect(defaultCategorizer({value:69.9999})).to.equal("target");
-          expect(defaultCategorizer({value:180.0001})).to.equal("target");
-          expect(defaultCategorizer({value:180.0002})).to.equal("high");
-          expect(defaultCategorizer({value:250.0001})).to.equal("high");
-          expect(defaultCategorizer({value:250.0002})).to.equal("veryhigh");
+        expect(defaultCategorizer({value:53.9998})).to.equal("verylow");
+        expect(defaultCategorizer({value:53.9999})).to.equal("low");
+        expect(defaultCategorizer({value:69.9998})).to.equal("low");
+        expect(defaultCategorizer({value:69.9999})).to.equal("target");
+        expect(defaultCategorizer({value:180.0001})).to.equal("target");
+        expect(defaultCategorizer({value:180.0002})).to.equal("high");
+        expect(defaultCategorizer({value:250.0001})).to.equal("high");
+        expect(defaultCategorizer({value:250.0002})).to.equal("veryhigh");
       });
     });
   });

--- a/test/categorize_test.js
+++ b/test/categorize_test.js
@@ -157,5 +157,17 @@ describe('Categorize', function() {
         expect(mmollCategorizer({value:14.0})).to.equal("veryhigh");
       });
     });
+    describe('with mg/dL conversion rounding allowances', function() {
+      it('should apply `0.0001` rounding allowances for mg/dL values', function() {
+          expect(defaultCategorizer({value:53.9998})).to.equal("verylow");
+          expect(defaultCategorizer({value:53.9999})).to.equal("low");
+          expect(defaultCategorizer({value:69.9998})).to.equal("low");
+          expect(defaultCategorizer({value:69.9999})).to.equal("target");
+          expect(defaultCategorizer({value:180.0001})).to.equal("target");
+          expect(defaultCategorizer({value:180.0002})).to.equal("high");
+          expect(defaultCategorizer({value:250.0001})).to.equal("high");
+          expect(defaultCategorizer({value:250.0002})).to.equal("veryhigh");
+      });
+    });
   });
 });

--- a/test/categorize_test.js
+++ b/test/categorize_test.js
@@ -24,10 +24,10 @@ var { MGDL_PER_MMOLL } = require('../js/data/util/constants');
 
 var categorizer = require('../js/data/util/categorize');
 var defaultBgClasses = {
-  'very-low': { boundary: 55 },
+  'very-low': { boundary: 54 },
   low: { boundary: 70 },
   target: { boundary: 180 },
-  high: { boundary: 300 },
+  high: { boundary: 250 },
 };
 var alternateBgClasses = {
   'very-low': { boundary: 60 },
@@ -36,10 +36,10 @@ var alternateBgClasses = {
   high: { boundary: 250 },
 };
 var mmollBgClasses = {
-  'very-low': { boundary: 55/MGDL_PER_MMOLL },
+  'very-low': { boundary: 54/MGDL_PER_MMOLL },
   low: { boundary: 70/MGDL_PER_MMOLL },
   target: { boundary: 180/MGDL_PER_MMOLL },
-  high: { boundary: 300/MGDL_PER_MMOLL },
+  high: { boundary: 250/MGDL_PER_MMOLL },
 };
 
 describe('Categorize', function() {
@@ -75,8 +75,8 @@ describe('Categorize', function() {
       it('should categorize 250 as "high"', function(){
         expect(defaultCategorizer({value:250})).to.equal("high");
       });
-      it('should categorize 300 as "high"', function(){
-        expect(defaultCategorizer({value:300})).to.equal("high");
+      it('should categorize 300 as "veryhigh"', function(){
+        expect(defaultCategorizer({value:300})).to.equal("veryhigh");
       });
       it('should categorize 350 as "veryhigh"', function(){
         expect(defaultCategorizer({value:350})).to.equal("veryhigh");
@@ -144,7 +144,7 @@ describe('Categorize', function() {
       it('should categorize 2.5 as "verylow"', function(){
         expect(mmollCategorizer({value:2.8})).to.equal("verylow");
       });
-      it('should categorize 3.2 as "low"', function(){
+      it('should categorize 3.2 as "verylow"', function(){
         expect(mmollCategorizer({value:3.2})).to.equal("low");
       });
       it('should categorize 3.7 as "low"', function(){
@@ -162,8 +162,8 @@ describe('Categorize', function() {
       it('should categorize 12.2 as "high"', function(){
         expect(mmollCategorizer({value:12.2})).to.equal("high");
       });
-      it('should categorize 15.8 as "high"', function(){
-        expect(mmollCategorizer({value:15.8})).to.equal("high");
+      it('should categorize 15.8 as "veryhigh"', function(){
+        expect(mmollCategorizer({value:15.8})).to.equal("veryhigh");
       });
       it('should categorize 22.0 as "veryhigh"', function(){
         expect(mmollCategorizer({value:22.0})).to.equal("veryhigh");

--- a/test/categorize_test.js
+++ b/test/categorize_test.js
@@ -157,17 +157,5 @@ describe('Categorize', function() {
         expect(mmollCategorizer({value:14.0})).to.equal("veryhigh");
       });
     });
-    describe('with mg/dL conversion rounding allowances', function() {
-      it('should apply `0.0001` rounding allowances for mg/dL values', function() {
-        expect(defaultCategorizer({value:53.9998})).to.equal("verylow");
-        expect(defaultCategorizer({value:53.9999})).to.equal("low");
-        expect(defaultCategorizer({value:69.9998})).to.equal("low");
-        expect(defaultCategorizer({value:69.9999})).to.equal("target");
-        expect(defaultCategorizer({value:180.0001})).to.equal("target");
-        expect(defaultCategorizer({value:180.0002})).to.equal("high");
-        expect(defaultCategorizer({value:250.0001})).to.equal("high");
-        expect(defaultCategorizer({value:250.0002})).to.equal("veryhigh");
-      });
-    });
   });
 });

--- a/test/categorize_test.js
+++ b/test/categorize_test.js
@@ -21,14 +21,14 @@ var chai = require('chai');
 var d3 = require('d3');
 var assert = chai.assert;
 var expect = chai.expect;
-var { MGDL_PER_MMOLL, DEFAULT_BG_BOUNDS } = require('../js/data/util/constants');
+var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS } = require('../js/data/util/constants');
 
 var categorizer = require('../js/data/util/categorize');
 var defaultBgClasses = {
-  'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
-  low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
-  target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
-  high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
+  'very-low': { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow },
+  low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
+  target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
+  high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
 };
 var alternateBgClasses = {
   'very-low': { boundary: 60 },
@@ -37,10 +37,10 @@ var alternateBgClasses = {
   high: { boundary: 250 },
 };
 var mmollBgClasses = {
-  'very-low': { boundary: d3.format('.1f')(DEFAULT_BG_BOUNDS.veryLow/MGDL_PER_MMOLL) },
-  low: { boundary: d3.format('.1f')(DEFAULT_BG_BOUNDS.targetLower/MGDL_PER_MMOLL) },
-  target: { boundary: d3.format('.1f')(DEFAULT_BG_BOUNDS.targetUpper/MGDL_PER_MMOLL) },
-  high: { boundary: d3.format('.1f')(DEFAULT_BG_BOUNDS.veryHigh/MGDL_PER_MMOLL) },
+  'very-low': { boundary: DEFAULT_BG_BOUNDS[MMOLL_UNITS].veryLow },
+  low: { boundary: DEFAULT_BG_BOUNDS[MMOLL_UNITS].targetLower },
+  target: { boundary: DEFAULT_BG_BOUNDS[MMOLL_UNITS].targetUpper },
+  high: { boundary: DEFAULT_BG_BOUNDS[MMOLL_UNITS].veryHigh },
 };
 
 describe('Categorize', function() {

--- a/test/constants_test.js
+++ b/test/constants_test.js
@@ -76,6 +76,6 @@ describe('constants', function() {
   });
 
   it('should define the BG_CLAMP_THRESHOLD in MMOLL_UNITS threshold as 600/MGDL_PER_MMOLL', function() {
-    expect(constants.BG_CLAMP_THRESHOLD[constants.MMOLL_UNITS]).to.equal(600/MGDL_PER_MMOLL);
+    expect(constants.BG_CLAMP_THRESHOLD[constants.MMOLL_UNITS]).to.equal(600/constants.MGDL_PER_MMOLL);
   });
 });

--- a/test/constants_test.js
+++ b/test/constants_test.js
@@ -40,42 +40,42 @@ describe('constants', function() {
   });
 
   it('should define the DEFAULT_BG_BOUNDS MGDL_UNITS veryLow threshold as 54', function() {
-    expect(constants.DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow).to.equal(54);
+    expect(constants.DEFAULT_BG_BOUNDS[constants.MGDL_UNITS].veryLow).to.equal(54);
   });
 
   it('should define the DEFAULT_BG_BOUNDS MGDL_UNITS targetLower threshold as 70', function() {
-    expect(constants.DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower).to.equal(70);
+    expect(constants.DEFAULT_BG_BOUNDS[constants.MGDL_UNITS].targetLower).to.equal(70);
   });
 
   it('should define the DEFAULT_BG_BOUNDS MGDL_UNITS targetUpper threshold as 180', function() {
-    expect(constants.DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper).to.equal(180);
+    expect(constants.DEFAULT_BG_BOUNDS[constants.MGDL_UNITS].targetUpper).to.equal(180);
   });
 
   it('should define the DEFAULT_BG_BOUNDS MGDL_UNITS veryHigh threshold as 250', function() {
-    expect(constants.DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh).to.equal(250);
+    expect(constants.DEFAULT_BG_BOUNDS[constants.MGDL_UNITS].veryHigh).to.equal(250);
   });
 
   it('should define the DEFAULT_BG_BOUNDS MMOLL_UNITS veryLow threshold as 3.0', function() {
-    expect(constants.DEFAULT_BG_BOUNDS[MMOLL_UNITS].veryLow).to.equal(3.0);
+    expect(constants.DEFAULT_BG_BOUNDS[constants.MMOLL_UNITS].veryLow).to.equal(3.0);
   });
 
   it('should define the DEFAULT_BG_BOUNDS MMOLL_UNITS targetLower threshold as 3.9', function() {
-    expect(constants.DEFAULT_BG_BOUNDS[MMOLL_UNITS].targetLower).to.equal(3.9);
+    expect(constants.DEFAULT_BG_BOUNDS[constants.MMOLL_UNITS].targetLower).to.equal(3.9);
   });
 
   it('should define the DEFAULT_BG_BOUNDS MMOLL_UNITS targetUpper threshold as 10.0', function() {
-    expect(constants.DEFAULT_BG_BOUNDS[MMOLL_UNITS].targetUpper).to.equal(10.0);
+    expect(constants.DEFAULT_BG_BOUNDS[constants.MMOLL_UNITS].targetUpper).to.equal(10.0);
   });
 
   it('should define the DEFAULT_BG_BOUNDS MMOLL_UNITS veryHigh threshold as 13.9', function() {
-    expect(constants.DEFAULT_BG_BOUNDS[MMOLL_UNITS].veryHigh).to.equal(13.9);
+    expect(constants.DEFAULT_BG_BOUNDS[constants.MMOLL_UNITS].veryHigh).to.equal(13.9);
   });
 
   it('should define the BG_CLAMP_THRESHOLD in MGDL_UNITS threshold as 600', function() {
-    expect(constants.BG_CLAMP_THRESHOLD[MGDL_UNITS]).to.equal(600);
+    expect(constants.BG_CLAMP_THRESHOLD[constants.MGDL_UNITS]).to.equal(600);
   });
 
   it('should define the BG_CLAMP_THRESHOLD in MMOLL_UNITS threshold as 600/MGDL_PER_MMOLL', function() {
-    expect(constants.BG_CLAMP_THRESHOLD[MMOLL_UNITS]).to.equal(600/MGDL_PER_MMOLL);
+    expect(constants.BG_CLAMP_THRESHOLD[constants.MMOLL_UNITS]).to.equal(600/MGDL_PER_MMOLL);
   });
 });

--- a/test/constants_test.js
+++ b/test/constants_test.js
@@ -38,4 +38,44 @@ describe('constants', function() {
   it('should define the MMOLL_UNITS conversion as mmol/L', function() {
     expect(constants.MMOLL_UNITS).to.equal('mmol/L');
   });
+
+  it('should define the DEFAULT_BG_BOUNDS MGDL_UNITS veryLow threshold as 54', function() {
+    expect(constants.DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow).to.equal(54);
+  });
+
+  it('should define the DEFAULT_BG_BOUNDS MGDL_UNITS targetLower threshold as 70', function() {
+    expect(constants.DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower).to.equal(70);
+  });
+
+  it('should define the DEFAULT_BG_BOUNDS MGDL_UNITS targetUpper threshold as 180', function() {
+    expect(constants.DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper).to.equal(180);
+  });
+
+  it('should define the DEFAULT_BG_BOUNDS MGDL_UNITS veryHigh threshold as 250', function() {
+    expect(constants.DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh).to.equal(250);
+  });
+
+  it('should define the DEFAULT_BG_BOUNDS MMOLL_UNITS veryLow threshold as 3.0', function() {
+    expect(constants.DEFAULT_BG_BOUNDS[MMOLL_UNITS].veryLow).to.equal(3.0);
+  });
+
+  it('should define the DEFAULT_BG_BOUNDS MMOLL_UNITS targetLower threshold as 3.9', function() {
+    expect(constants.DEFAULT_BG_BOUNDS[MMOLL_UNITS].targetLower).to.equal(3.9);
+  });
+
+  it('should define the DEFAULT_BG_BOUNDS MMOLL_UNITS targetUpper threshold as 10.0', function() {
+    expect(constants.DEFAULT_BG_BOUNDS[MMOLL_UNITS].targetUpper).to.equal(10.0);
+  });
+
+  it('should define the DEFAULT_BG_BOUNDS MMOLL_UNITS veryHigh threshold as 13.9', function() {
+    expect(constants.DEFAULT_BG_BOUNDS[MMOLL_UNITS].veryHigh).to.equal(13.9);
+  });
+
+  it('should define the BG_CLAMP_THRESHOLD in MGDL_UNITS threshold as 600', function() {
+    expect(constants.BG_CLAMP_THRESHOLD[MGDL_UNITS]).to.equal(600);
+  });
+
+  it('should define the BG_CLAMP_THRESHOLD in MMOLL_UNITS threshold as 600/MGDL_PER_MMOLL', function() {
+    expect(constants.BG_CLAMP_THRESHOLD[MMOLL_UNITS]).to.equal(600/MGDL_PER_MMOLL);
+  });
 });

--- a/test/format_test.js
+++ b/test/format_test.js
@@ -55,7 +55,7 @@ describe('format utility', function() {
         annotations: [
           {
             code: 'bg/out-of-range',
-            threshold: BG_CLAMP_THRESHOLD,
+            threshold: BG_CLAMP_THRESHOLD[MGDL_UNITS],
             value: 'high',
           },
         ],
@@ -73,7 +73,7 @@ describe('format utility', function() {
         annotations: [
           {
             code: 'bg/out-of-range',
-            threshold: BG_CLAMP_THRESHOLD,
+            threshold: BG_CLAMP_THRESHOLD[MGDL_UNITS],
             value: 'high',
           },
         ],

--- a/test/format_test.js
+++ b/test/format_test.js
@@ -22,7 +22,7 @@ var assert = chai.assert;
 var expect = chai.expect;
 
 var fmt = require('../js/data/util/format');
-var { MGDL_UNITS, MMOLL_UNITS } = require('../js/data/util/constants');
+var { MGDL_UNITS, MMOLL_UNITS, BG_CLAMP_THRESHOLD } = require('../js/data/util/constants');
 
 describe('format utility', function() {
   describe('tooltipBG', function() {
@@ -55,7 +55,7 @@ describe('format utility', function() {
         annotations: [
           {
             code: 'bg/out-of-range',
-            threshold: 600,
+            threshold: BG_CLAMP_THRESHOLD,
             value: 'high',
           },
         ],
@@ -73,7 +73,7 @@ describe('format utility', function() {
         annotations: [
           {
             code: 'bg/out-of-range',
-            threshold: 600,
+            threshold: BG_CLAMP_THRESHOLD,
             value: 'high',
           },
         ],

--- a/test/nurseshark_test.js
+++ b/test/nurseshark_test.js
@@ -24,7 +24,7 @@ var expect = chai.expect;
 var _ = require('lodash');
 
 var dt = require('../js/data/util/datetime');
-var { MGDL_UNITS, MMOLL_UNITS } = require('../js/data/util/constants');
+var { MGDL_UNITS, MMOLL_UNITS, MGDL_PER_MMOLL } = require('../js/data/util/constants');
 
 var nurseshark = require('../plugins/nurseshark');
 
@@ -254,9 +254,9 @@ describe('nurseshark', function() {
         timezoneOffset: 0
       }];
       var res = nurseshark.processData(bgs, MGDL_UNITS).processedData;
-      expect(res[0].value).to.equal(256);
-      expect(res[1].value).to.equal(45);
-      expect(res[2].value).to.equal(127);
+      expect(res[0].value).to.equal(bgs[0].value * MGDL_PER_MMOLL);
+      expect(res[1].value).to.equal(bgs[1].value * MGDL_PER_MMOLL);
+      expect(res[2].value).to.equal(bgs[2].value * MGDL_PER_MMOLL);
     });
 
     it('should translate wizard bg-related fields to mg/dL when such units specified', function() {
@@ -276,12 +276,12 @@ describe('nurseshark', function() {
         timezoneOffset: 0
       }];
       var res = nurseshark.processData(datum, MGDL_UNITS).processedData[0];
-      expect(res.bgInput).to.equal(273);
-      expect(res.bgTarget.low).to.equal(100);
-      expect(res.bgTarget.high).to.equal(100);
-      expect(res.bgTarget.target).to.equal(100);
-      expect(res.bgTarget.range).to.equal(10);
-      expect(res.insulinSensitivity).to.equal(68);
+      expect(res.bgInput).to.equal(datum[0].bgInput * MGDL_PER_MMOLL);
+      expect(res.bgTarget.low).to.equal(datum[0].bgTarget.low * MGDL_PER_MMOLL);
+      expect(res.bgTarget.high).to.equal(datum[0].bgTarget.high * MGDL_PER_MMOLL);
+      expect(res.bgTarget.target).to.equal(datum[0].bgTarget.target * MGDL_PER_MMOLL);
+      expect(res.bgTarget.range).to.equal(datum[0].bgTarget.range * MGDL_PER_MMOLL);
+      expect(res.insulinSensitivity).to.equal(datum[0].insulinSensitivity * MGDL_PER_MMOLL);
     });
 
     it('should translate pumpSettings bg-related fields to mg/dL when such units specified', function() {
@@ -310,10 +310,10 @@ describe('nurseshark', function() {
         timezoneOffset: 0
       }];
       var res = nurseshark.processData(settings, MGDL_UNITS).processedData[0];
-      expect(res.bgTarget[0].target).to.equal(120);
-      expect(res.bgTarget[0].range).to.equal(10);
-      expect(res.insulinSensitivity[0].amount).to.equal(80);
-      expect(res.insulinSensitivity[1].amount).to.equal(90);
+      expect(res.bgTarget[0].target).to.equal(settings[0].bgTarget[0].target * MGDL_PER_MMOLL);
+      expect(res.bgTarget[0].range).to.equal(settings[0].bgTarget[0].range * MGDL_PER_MMOLL);
+      expect(res.insulinSensitivity[0].amount).to.equal(settings[0].insulinSensitivity[0].amount * MGDL_PER_MMOLL);
+      expect(res.insulinSensitivity[1].amount).to.equal(settings[0].insulinSensitivity[1].amount * MGDL_PER_MMOLL);
     });
 
     it('should reshape basalSchedules from an object to an array', function() {

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -37,11 +37,12 @@ var TidelineData = require('../js/tidelinedata');
 describe('TidelineData', function() {
   var td = new TidelineData([]);
   var bgUnits = MGDL_UNITS;
+  var roundingAllowance = 0.0001;
   var bgClasses = {
-    'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
-    low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
-    target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
-    high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
+    'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow - roundingAllowance},
+    low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower - roundingAllowance},
+    target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper + roundingAllowance},
+    high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh + roundingAllowance},
     'very-high': { boundary: BG_CLAMP_THRESHOLD[bgUnits] }
   };
   it('should be a function', function() {
@@ -815,6 +816,13 @@ describe('TidelineData', function() {
 
     it('should set bgClasses to the default', function() {
       expect(thisTd.bgClasses).to.eql(bgClasses);
+    });
+
+    it('should apply `0.0001` rounding allowances for mg/dL values', function() {
+      expect(thisTd.bgClasses['very-low'].boundary).to.equal(DEFAULT_BG_BOUNDS[bgUnits].veryLow - roundingAllowance);
+      expect(thisTd.bgClasses.low.boundary).to.equal(DEFAULT_BG_BOUNDS[bgUnits].targetLower - roundingAllowance);
+      expect(thisTd.bgClasses.target.boundary).to.equal(DEFAULT_BG_BOUNDS[bgUnits].targetUpper + roundingAllowance);
+      expect(thisTd.bgClasses.high.boundary).to.equal(DEFAULT_BG_BOUNDS[bgUnits].veryHigh + roundingAllowance);
     });
 
     it('should default bgUnits to mg/dL', function() {

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -37,10 +37,10 @@ var TidelineData = require('../js/tidelinedata');
 describe('TidelineData', function() {
   var td = new TidelineData([]);
   var bgClasses = {
-    'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
-    low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
-    target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
-    high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
+    'very-low': { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow },
+    low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
+    target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
+    high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
     'very-high': { boundary: BG_CLAMP_THRESHOLD }
   };
   it('should be a function', function() {

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -34,7 +34,7 @@ var { MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS, BG_CLAMP_THRESHOLD } = require
 
 var TidelineData = require('../js/tidelinedata');
 
-var bgUnits = MGDL_UNITS;
+var bgUnits;
 
 describe('TidelineData', function() {
   var td = new TidelineData([]);
@@ -44,7 +44,7 @@ describe('TidelineData', function() {
     low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
     target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
     high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
-    'very-high': { boundary: BG_CLAMP_THRESHOLD }
+    'very-high': { boundary: BG_CLAMP_THRESHOLD[bgUnits] }
   };
   it('should be a function', function() {
     assert.isFunction(TidelineData);

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -37,11 +37,11 @@ var TidelineData = require('../js/tidelinedata');
 describe('TidelineData', function() {
   var td = new TidelineData([]);
   var bgClasses = {
-    'very-low': { boundary: 55 },
+    'very-low': { boundary: 54 },
     low: { boundary: 70 },
     target: { boundary: 180 },
-    high: { boundary: 300 },
-    'very-high': { boundary: 600 }
+    high: { boundary: 180 },
+    'very-high': { boundary: 250 }
   };
   it('should be a function', function() {
     assert.isFunction(TidelineData);

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -33,7 +33,8 @@ var types = require('../dev/testpage/types');
 var { MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS, BG_CLAMP_THRESHOLD } = require('../js/data/util/constants');
 
 var TidelineData = require('../js/tidelinedata');
-bgUnits = MGDL_UNITS;
+
+var bgUnits = MGDL_UNITS;
 
 describe('TidelineData', function() {
   var td = new TidelineData([]);

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -34,11 +34,9 @@ var { MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS, BG_CLAMP_THRESHOLD } = require
 
 var TidelineData = require('../js/tidelinedata');
 
-var bgUnits;
-
 describe('TidelineData', function() {
   var td = new TidelineData([]);
-  bgUnits = MGDL_UNITS;
+  var bgUnits = MGDL_UNITS;
   var bgClasses = {
     'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
     low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -36,11 +36,12 @@ var TidelineData = require('../js/tidelinedata');
 
 describe('TidelineData', function() {
   var td = new TidelineData([]);
+  bgUnits = MGDL_UNITS;
   var bgClasses = {
-    'very-low': { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryLow },
-    low: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetLower },
-    target: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].targetUpper },
-    high: { boundary: DEFAULT_BG_BOUNDS[MGDL_UNITS].veryHigh },
+    'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
+    low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
+    target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
+    high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
     'very-high': { boundary: BG_CLAMP_THRESHOLD }
   };
   it('should be a function', function() {

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -37,10 +37,10 @@ var TidelineData = require('../js/tidelinedata');
 describe('TidelineData', function() {
   var td = new TidelineData([]);
   var bgClasses = {
-    'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
-    low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
-    target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
-    high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
+    'very-low': { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryLow },
+    low: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetLower },
+    target: { boundary: DEFAULT_BG_BOUNDS[bgUnits].targetUpper },
+    high: { boundary: DEFAULT_BG_BOUNDS[bgUnits].veryHigh },
     'very-high': { boundary: BG_CLAMP_THRESHOLD }
   };
   it('should be a function', function() {

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -33,6 +33,7 @@ var types = require('../dev/testpage/types');
 var { MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS, BG_CLAMP_THRESHOLD } = require('../js/data/util/constants');
 
 var TidelineData = require('../js/tidelinedata');
+bgUnits = MGDL_UNITS;
 
 describe('TidelineData', function() {
   var td = new TidelineData([]);

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -40,8 +40,8 @@ describe('TidelineData', function() {
     'very-low': { boundary: 54 },
     low: { boundary: 70 },
     target: { boundary: 180 },
-    high: { boundary: 180 },
-    'very-high': { boundary: 250 }
+    high: { boundary: 250 },
+    'very-high': { boundary: 600 }
   };
   it('should be a function', function() {
     assert.isFunction(TidelineData);

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -30,18 +30,18 @@ var crossfilter = require('crossfilter');
 var moment = require('moment-timezone');
 
 var types = require('../dev/testpage/types');
-var { MGDL_UNITS, MMOLL_UNITS } = require('../js/data/util/constants');
+var { MGDL_UNITS, MMOLL_UNIT, DEFAULT_BG_BOUNDS, BG_CLAMP_THRESHOLD } = require('../js/data/util/constants');
 
 var TidelineData = require('../js/tidelinedata');
 
 describe('TidelineData', function() {
   var td = new TidelineData([]);
   var bgClasses = {
-    'very-low': { boundary: 54 },
-    low: { boundary: 70 },
-    target: { boundary: 180 },
-    high: { boundary: 250 },
-    'very-high': { boundary: 600 }
+    'very-low': { boundary: DEFAULT_BG_BOUNDS.veryLow },
+    low: { boundary: DEFAULT_BG_BOUNDS.targetLower },
+    target: { boundary: DEFAULT_BG_BOUNDS.targetUpper },
+    high: { boundary: DEFAULT_BG_BOUNDS.veryHigh },
+    'very-high': { boundary: BG_CLAMP_THRESHOLD }
   };
   it('should be a function', function() {
     assert.isFunction(TidelineData);

--- a/test/tidelinedata_test.js
+++ b/test/tidelinedata_test.js
@@ -30,7 +30,7 @@ var crossfilter = require('crossfilter');
 var moment = require('moment-timezone');
 
 var types = require('../dev/testpage/types');
-var { MGDL_UNITS, MMOLL_UNIT, DEFAULT_BG_BOUNDS, BG_CLAMP_THRESHOLD } = require('../js/data/util/constants');
+var { MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS, BG_CLAMP_THRESHOLD } = require('../js/data/util/constants');
 
 var TidelineData = require('../js/tidelinedata');
 


### PR DESCRIPTION
See https://trello.com/c/OKj6Qyji for details.

Related PRs:
tidepool-org/blip#480
tidepool-org/viz#107

The primary purpose of this PR is outlined in the card above, however, a rounding issue was uncovered when the categorization unit tests were updated to test values in and slightly outside of each threshold.

It was also decided to move all default threshold definitions to a constant to allow any future changes to be much simpler.

As per our internal discussions on the matter, we don't want to do any rounding at all before classification/categorization, and so the bg rounding during `mmol/L -> mg/dL` conversion has been removed from the nurseshark plugin.