### PR TITLE
Bg defaults daily ticks regression fix

### DIFF
--- a/js/plot/util/scales.js
+++ b/js/plot/util/scales.js
@@ -22,6 +22,7 @@ var _ = require('lodash');
 
 var commonbolus = require('./commonbolus');
 var { MGDL_PER_MMOLL, MGDL_UNITS, MMOLL_UNITS, DEFAULT_BG_BOUNDS } = require('../../data/util/constants');
+var format = require('../../data/util/format');
 
 var scales = function(opts) {
   opts = _.assign({}, opts) || {};
@@ -97,7 +98,7 @@ var scales = function(opts) {
         return [];
       }
       var defaultTicks = _.map(_.values(_.omit(opts.bgClasses, ['very-high', 'very-low'])), function(n) {
-        return _.get(n, 'boundary');
+        return format.tooltipBGValue(_.get(n, 'boundary'), bgUnits);
       }).sort(function (a, b) { return a - b; });
 
       var ext = d3.extent(data, function(d) { return d.value; });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes a regression introduced in the new BG defaults release (`0.7.4`) that caused the BG ticks on the daily view y axis to disappear when displaying in `mg/dL` units.

See https://trello.com/c/EJQHZnyv