### PR TITLE
Fix weekly range used for stats calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "0.8.0",
+  "version": "1.8.1-weekly-range-fix.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/chartweeklyfactory.js
+++ b/plugins/blip/chartweeklyfactory.js
@@ -42,7 +42,7 @@ function chartWeeklyFactory(el, options) {
   _.defaults(options, defaults);
 
   var emitter = new EventEmitter();
-  var chart = tideline.twoWeek(emitter);
+  var chart = tideline.twoWeek(emitter, options.timePrefs);
   chart.options = options;
   chart.emitter = emitter;
 


### PR DESCRIPTION
See https://trello.com/c/Jpi5YurW for details.

Basically, this applies a timezone offset when available for the two-week window of the weekly view.  It also fixes an issue where the window data was offset by 12 hours from the date range.

One other small fix was that there was a mechanism to only re-calculate the stats when the dates changed.  This was flawed, and was recalculating on every scroll movement.  It now works as intended.

Related PR:
tidepool-org/blip#490