### PR TITLE
Disable bg annotation

### DIFF
--- a/js/plot/util/annotations/annotationdefinitions.js
+++ b/js/plot/util/annotations/annotationdefinitions.js
@@ -24,6 +24,7 @@ var format = require('../../../data/util/format');
 var definitions = {
   DISABLED: [
     'basal/auto',
+    'bg/out-of-range',
     'medtronic600/smbg/bg-reading-received',
     'medtronic600/smbg/user-accepted-remote-bg',
     'medtronic600/smbg/user-rejected-remote-bg',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "1.8.11",
+  "version": "1.8.12-disable-bg-annotation.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "1.8.12-disable-bg-annotation.1",
+  "version": "1.8.12-disable-bg-annotation.2",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/test/annotations_test.js
+++ b/test/annotations_test.js
@@ -72,6 +72,7 @@ describe('annotation definitions', function() {
     it('should define an array of disabled annotations', function() {
       expect(annotations.DISABLED).to.eql([
         'basal/auto',
+        'bg/out-of-range',
         'medtronic600/smbg/bg-reading-received',
         'medtronic600/smbg/user-accepted-remote-bg',
         'medtronic600/smbg/user-rejected-remote-bg',


### PR DESCRIPTION
Adds `bg/out-of-range` to the `DISABLED` annotations list as the rendering for those have been moved to the newer bg tooltips.

blip PR: https://github.com/tidepool-org/blip/pull/511
Trello card: https://trello.com/c/pQv4sTKV