### PR TITLE
Carb rendering

### DIFF
--- a/css/tideline.less
+++ b/css/tideline.less
@@ -785,7 +785,8 @@ text.d3-tabular-ui {
 }
 
 .d3-wizard-group,
-.d3-bolus-group {
+.d3-bolus-group,
+.d3-carb-group {
   cursor: default;
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -57,6 +57,7 @@ module.exports = {
     smbg: require('./plot/smbg'),
     suspend: require('./plot/suspend'), 
     wizard: require('./plot/wizard'),
+    carb: require('./plot/carb'),
     stats: {
       puddle: require('./plot/stats/puddle'),
     },

--- a/js/plot/carb.js
+++ b/js/plot/carb.js
@@ -1,0 +1,112 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2014, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+/* jshint esversion:6 */
+
+var d3 = require('d3');
+var _ = require('lodash');
+
+module.exports = function(pool, opts) {
+  var defaults = {
+    r: 14,
+    carbPadding: 4
+  };
+
+  _.defaults(opts, defaults);
+
+  var xPos = function(d) {
+    return opts.xScale(Date.parse(d.normalTime));
+  };
+
+  function carb(selection) {
+    var yPos = opts.r + opts.carbPadding;
+    opts.xScale = pool.xScale().copy();
+    selection.each(function(currentData) {
+      var filteredData = _.filter(currentData, (data) => {
+        return _.get(data, 'nutrition.carbohydrate.net', false);
+      });
+      var allCarbs = d3
+        .select(this)
+        .selectAll('circle.d3-carbs-only')
+        .data(filteredData, function(d) {
+          return d.id;
+        });
+      var carbGroup = allCarbs.enter()
+        .append('g')
+        .attr({
+          'class': 'd3-carb-group',
+          id: function(d) {
+            return 'carb_group_' + d.id;
+          }
+        });
+
+      carbGroup.append('circle').attr({
+        cx: xPos,
+        cy: yPos,
+        r: function(d) {
+          return opts.r;
+        },
+        'stroke-width': 0,
+        class: 'd3-circle-carbs d3-carbs-only',
+        id: function(d) {
+          return 'carbs_' + d.id;
+        }
+      });
+
+      carbGroup
+        .append('text')
+        .text(function(d) {
+          return d.nutrition.carbohydrate.net;
+        })
+        .attr({
+          x: xPos,
+          y: yPos,
+          class: 'd3-carbs-text'
+        });
+
+      allCarbs.exit().remove();
+
+      // tooltips
+      selection.selectAll('.d3-carb-group').on('mouseover', function() {        
+        var parentContainer = document
+          .getElementsByClassName('patient-data')[0]
+          .getBoundingClientRect();
+        var container = this.getBoundingClientRect();
+        container.y = container.top - parentContainer.top;
+
+        carb.addTooltip(d3.select(this).datum(), container);
+      });
+
+      selection.selectAll('.d3-carb-group').on('mouseout', function() {
+        if (_.get(opts, 'onCarbOut', false)) {
+          opts.onCarbOut();
+        }
+      });
+    });
+  }
+
+  carb.addTooltip = function(d, rect) {
+    if (_.get(opts, 'onCarbHover', false)) {
+      opts.onCarbHover({
+        data: d,
+        rect: rect
+      });
+    }
+  };
+
+  return carb;
+};

--- a/js/validation/validate.js
+++ b/js/validation/validate.js
@@ -36,6 +36,7 @@ var schemas = {
   cbg: require('./bg'),
   common: require('./common'),
   deviceEvent: schema(),
+  food: schema(),
   message: require('./message'),
   pumpSettings: require('./pumpSettings'),
   smbg: require('./bg'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "1.11.0-release.1",
+  "version": "1.12.0-carb-rendering.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/chartdailyfactory.js
+++ b/plugins/blip/chartdailyfactory.js
@@ -291,6 +291,13 @@ function chartDailyFactory(el, options) {
       onBolusOut: options.onBolusOut,
     }), true, true);
 
+    poolBolus.addPlotType('food', tideline.plot.carb(poolBolus, {
+      emitter: emitter,
+      timezoneAware: chart.options.timePrefs.timezoneAware,
+      onCarbHover: options.onCarbHover,
+      onCarbOut: options.onCarbOut,
+    }), true, true);
+
     // quick bolus data to wizard pool
     poolBolus.addPlotType('bolus', tideline.plot.quickbolus(poolBolus, {
       yScale: scaleBolus,

--- a/plugins/nurseshark/index.js
+++ b/plugins/nurseshark/index.js
@@ -350,6 +350,10 @@ function getHandlers(bgUnits) {
       }
       return d;
     },
+    food: function(d) {
+      d = cloneDeep(d);
+      return d;
+    },
     message: function(d) {
       return nurseshark.reshapeMessage(d);
     },


### PR DESCRIPTION
Adds a passthrough for `food` data in the processing pipeline (basically behaves like `deviceEvent` for now) and renders the carbohydrate for data very similarly to carbs for a `wizard` event.

Pairs well with:
viz: https://github.com/tidepool-org/viz/pull/129
blip: https://github.com/tidepool-org/blip/pull/537

Trello: https://trello.com/c/0WUNaQS6