### PR TITLE
Update lodash to version 4.17.15.  Version bump to 1.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
     "duration-js": "4.0.0",
     "i18next": "11.9.0",
     "intl": "1.2.5",
-    "lodash": "4.17.11",
+    "lodash": "4.17.15",
     "moment-timezone": "0.5.21",
     "react": "15.6.2",
     "react-addons-pure-render-mixin": "15.6.2",


### PR DESCRIPTION
Hello,

I'm working on on a program analysis tool for some research and I noticed you are using version 4.17.11 of lodash. lodash@4.17.11 has a vulnerability in the defaultsDeep method which is used in this repository in `js/tidelinedata.js`.

This PR bumps the version of lodash to 4.17.15, the latest version as of this writing. I saw that you pin all of your dependencies to specific versions and have respected that with this PR.

Let me know if you have any questions or would like to discuss further! Thanks!