### PR TITLE
[WEB-993] Add option to exclude days with no boluses from basics calendar aggregations and stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "1.20.0-web-54-basics-date-range-selection.3",
+  "version": "1.21.0-web-993-disable-basic-dates.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/basics/chartbasicsfactory.js
+++ b/plugins/blip/basics/chartbasicsfactory.js
@@ -49,6 +49,7 @@ class BasicsChart extends React.Component {
     bgClasses: PropTypes.object.isRequired,
     bgUnits: PropTypes.string.isRequired,
     data: PropTypes.object.isRequired,
+    excludeDaysWithoutBolus: PropTypes.bool,
     onSelectDay: PropTypes.func.isRequired,
     patient: PropTypes.object.isRequired,
     permsOfLoggedInUser: PropTypes.object.isRequired,
@@ -221,6 +222,7 @@ class BasicsChart extends React.Component {
           chartWidth={self.props.size.width}
           data={aggregationsByDate[section.type]}
           days={days}
+          excludeDaysWithoutBolus={self.props.excludeDaysWithoutBolus}
           labels={section.labels}
           name={section.name}
           onSelectDay={self.props.onSelectDay}

--- a/plugins/blip/basics/components/CalendarContainer.js
+++ b/plugins/blip/basics/components/CalendarContainer.js
@@ -185,6 +185,7 @@ var CalendarContainer = createReactClass({
       var nextDay = self.props.days[index + 1] || {};
       var dateData = _.get(data, day.date, {});
       var type = self.props.source || self.props.type;
+      var isExcludedBolusDay = (type === 'boluses' && _.isEmpty(dateData) && self.props.excludeDaysWithoutBolus);
 
       if (!_.isEmpty(dateData) && self.props.hasHover && self.state.hoverDate === day.date) {
         return (
@@ -209,7 +210,7 @@ var CalendarContainer = createReactClass({
             chartWidth={self.props.chartWidth}
             data={dateData}
             date={day.date}
-            outOfRange={day.type === 'outOfRange'}
+            outOfRange={day.type === 'outOfRange' || isExcludedBolusDay}
             isFirst={index === 0}
             mostRecent={day.type === 'inRange' && nextDay.type === 'outOfRange'}
             onHover={self.onHover}

--- a/plugins/blip/basics/components/DashboardSection.js
+++ b/plugins/blip/basics/components/DashboardSection.js
@@ -60,6 +60,7 @@ class DashboardSection extends React.Component {
           chartWidth={this.props.chartWidth}
           data={this.props.data}
           days={this.props.days}
+          excludeDaysWithoutBolus={this.props.excludeDaysWithoutBolus}
           hasHover={section.hasHover}
           hoverDisplay={section.hoverDisplay}
           onSelectDay={this.props.onSelectDay}


### PR DESCRIPTION
See [WEB-993]

Goes with:
tidepool-org/blip#843
tidepool-org/viz#234

[WEB-993]: https://tidepool.atlassian.net/browse/WEB-993