### PR TITLE
[WEB-775] sitechange selection regression fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "1.24.0-rc.1",
+  "version": "1.24.0-rc.2",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/basics/chartbasicsfactory.js
+++ b/plugins/blip/basics/chartbasicsfactory.js
@@ -65,6 +65,16 @@ class BasicsChart extends React.Component {
     return !!(basal || bolus || wizard);
   };
 
+  _siteChangeDataAvailable = () => {
+    const siteChangeDataCount = _.reduce(
+      _.get(this.props, 'data.data.current.aggregationsByDate.siteChanges.byDate'),
+      (result, value) => result + _.max(_.values(value.subtotals)),
+      0
+    );
+
+    return siteChangeDataCount > 0
+  };
+
   _availableDeviceData = () => {
     const { bgSources } = _.get(this.props, 'data.metaData', {});
 
@@ -173,8 +183,14 @@ class BasicsChart extends React.Component {
         if (_.isArray(selectorOptions.rows)) selectorOptions.rows = _.chunk(_.orderBy(selectorOptions.rows, 'selectorIndex'), section.perRow || 3);
       }
 
+      let active = !section.disabled;
+
+      if (isSiteChanges) {
+        active = !section.disabled || this._siteChangeDataAvailable()
+      }
+
       _.defaults(section, {
-        active: !section.disabled,
+        active,
         chart,
         container: CalendarContainer,
         hasHover,


### PR DESCRIPTION
Part of [WEB-775]

When cleanup up the code in `viz` responsible for creating the basics calendar section definitions, it caused the sitechange source selection to stop working.  This fixes that.  I could have undone the 'cleanup' in the viz repo, but I feel this is a better way to determine when to show the 'emptyText' and when to show the sitechange source selector.

Viz PR: https://github.com/tidepool-org/viz/pull/261

[WEB-775]: https://tidepool.atlassian.net/browse/WEB-775