### PR TITLE
[WEB-2512,WEB-2514] Fix disabled rendering issues for basics calendar section rerendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tideline",
-  "version": "1.26.0",
+  "version": "1.27.0-web-2055-basics-basals-updates.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/basics/chartbasicsfactory.js
+++ b/plugins/blip/basics/chartbasicsfactory.js
@@ -101,6 +101,7 @@ class BasicsChart extends React.Component {
     this.setSectionsToState();
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
     let reRenderSections = false;
 


### PR DESCRIPTION
Addresses [WEB-2512], [WEB-2514]

Basically, the basics chart was not rerendering if the disabled state for a calendar section changed

Related PR: https://github.com/tidepool-org/blip/pull/1273](https://github.com/tidepool-org/blip/pull/1273)

[WEB-2512]: https://tidepool.atlassian.net/browse/WEB-2512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-2514]: https://tidepool.atlassian.net/browse/WEB-2514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ