### PR TITLE
[WEB-3219] Truncate future unknown basal durations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.30.0-rc.3",
+  "version": "1.30.0-rc.4",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/basics/components/sitechange/Change.js
+++ b/plugins/blip/basics/components/sitechange/Change.js
@@ -50,7 +50,7 @@ class Change extends React.Component {
       'Change--cannula': (this.props.type === constants.SITE_CHANGE_CANNULA),
       'Change--tubing': (this.props.type === constants.SITE_CHANGE_TUBING),
       'Change--reservoir': (this.props.type === constants.SITE_CHANGE_RESERVOIR),
-      'Change--loop-tubing': (_.includes([constants.DIY_LOOP, constants.TIDEPOOL_LOOP].map(_.lowerCase), this.props.manufacturer) && this.props.type === constants.SITE_CHANGE_TUBING),
+      'Change--loop-tubing': (_.includes(_.map([constants.DIY_LOOP, constants.TIDEPOOL_LOOP], _.lowerCase), this.props.manufacturer) && this.props.type === constants.SITE_CHANGE_TUBING),
     });
 
     return (


### PR DESCRIPTION
[WEB-3219]

This is just a minor code consistency tweak - not necessarily related to the Jira ticket, but wanted to include it in the release candidate.

Related PRs:
https://github.com/tidepool-org/viz/pull/407
https://github.com/tidepool-org/blip/pull/1441


[WEB-3219]: https://tidepool.atlassian.net/browse/WEB-3219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ