### PR TITLE
WEB-3399 - Override/Underride Precision

### DIFF
--- a/js/plot/quickbolus.js
+++ b/js/plot/quickbolus.js
@@ -74,14 +74,14 @@ module.exports = function(pool, opts) {
 
       // boluses where recommended > delivered
       var underride = boluses.filter(function(d) {
-        return commonbolus.getRecommended(d) > commonbolus.getDelivered(d);
+        return commonbolus.isUnderride(d);
       });
 
       drawBolus.underride(underride);
 
       // boluses where delivered > recommended
       var override = boluses.filter(function(d) {
-        return commonbolus.getDelivered(d) > commonbolus.getRecommended(d);
+        return commonbolus.isOverride(d);
       });
 
       drawBolus.override(override);

--- a/js/plot/quickbolus.js
+++ b/js/plot/quickbolus.js
@@ -72,14 +72,14 @@ module.exports = function(pool, opts) {
 
       drawBolus.extended(extended);
 
-      // boluses where recommended > delivered
+      // boluses where recommended > programmed
       var underride = boluses.filter(function(d) {
         return commonbolus.isUnderride(d);
       });
 
       drawBolus.underride(underride);
 
-      // boluses where delivered > recommended
+      // boluses where programmed > recommended
       var override = boluses.filter(function(d) {
         return commonbolus.isOverride(d);
       });

--- a/js/plot/util/commonbolus.js
+++ b/js/plot/util/commonbolus.js
@@ -152,12 +152,16 @@ module.exports = {
     const amountRecommended = module.exports.getRecommended(d);
     const amountProgrammed = module.exports.getProgrammed(d);
 
+    if (!amountRecommended) return false;
+
     return module.exports.isDifferentBeyondPrecision(amountRecommended, amountProgrammed, 2) && amountProgrammed > amountRecommended;
   },
 
   isUnderride: (d) => {
     const amountRecommended = module.exports.getRecommended(d);
     const amountProgrammed = module.exports.getProgrammed(d);
+
+    if (!amountRecommended) return false;
 
     return module.exports.isDifferentBeyondPrecision(amountRecommended, amountProgrammed, 2) && amountProgrammed < amountRecommended;
   }

--- a/js/plot/util/commonbolus.js
+++ b/js/plot/util/commonbolus.js
@@ -142,5 +142,23 @@ module.exports = {
       return NaN;
     }
     return d.expectedDuration || d.duration;
+  },
+
+  isDifferentBeyondPrecision: (a, b, precision) => {
+    return _.round(a, precision) !== _.round(b, precision);
+  },
+
+  isOverride: (d) => {
+    const amountRecommended = module.exports.getRecommended(d);
+    const amountProgrammed = module.exports.getProgrammed(d);
+
+    return module.exports.isDifferentBeyondPrecision(amountRecommended, amountProgrammed, 2) && amountProgrammed > amountRecommended;
+  },
+
+  isUnderride: (d) => {
+    const amountRecommended = module.exports.getRecommended(d);
+    const amountProgrammed = module.exports.getProgrammed(d);
+
+    return module.exports.isDifferentBeyondPrecision(amountRecommended, amountProgrammed, 2) && amountProgrammed < amountRecommended;
   }
 };

--- a/js/plot/util/commonbolus.js
+++ b/js/plot/util/commonbolus.js
@@ -149,20 +149,22 @@ module.exports = {
   },
 
   isOverride: (d) => {
-    const amountRecommended = module.exports.getRecommended(d);
-    const amountProgrammed = module.exports.getProgrammed(d);
+    const self = module.exports;
+    const amountRecommended = self.getRecommended(d);
+    const amountProgrammed = self.getProgrammed(d);
 
     if (!amountRecommended) return false;
 
-    return module.exports.isDifferentBeyondPrecision(amountRecommended, amountProgrammed, 2) && amountProgrammed > amountRecommended;
+    return self.isDifferentBeyondPrecision(amountRecommended, amountProgrammed, 2) && amountProgrammed > amountRecommended;
   },
 
   isUnderride: (d) => {
-    const amountRecommended = module.exports.getRecommended(d);
-    const amountProgrammed = module.exports.getProgrammed(d);
+    const self = module.exports;
+    const amountRecommended = self.getRecommended(d);
+    const amountProgrammed = self.getProgrammed(d);
 
     if (!amountRecommended) return false;
 
-    return module.exports.isDifferentBeyondPrecision(amountRecommended, amountProgrammed, 2) && amountProgrammed < amountRecommended;
+    return self.isDifferentBeyondPrecision(amountRecommended, amountProgrammed, 2) && amountProgrammed < amountRecommended;
   }
 };

--- a/js/plot/wizard.js
+++ b/js/plot/wizard.js
@@ -94,14 +94,14 @@ module.exports = function(pool, opts) {
 
       // boluses where recommended > delivered
       var underride = boluses.filter(function(d) {
-        return commonbolus.getRecommended(d) > commonbolus.getDelivered(d);
+        return commonbolus.isUnderride(d);
       });
 
       drawBolus.underride(underride);
 
       // boluses where delivered > recommended
       var override = boluses.filter(function(d) {
-        return commonbolus.getDelivered(d) > commonbolus.getRecommended(d);
+        return commonbolus.isOverride(d);
       });
 
       drawBolus.override(override);

--- a/js/plot/wizard.js
+++ b/js/plot/wizard.js
@@ -92,14 +92,14 @@ module.exports = function(pool, opts) {
 
       drawBolus.extended(extended);
 
-      // boluses where recommended > delivered
+      // boluses where recommended > programmed
       var underride = boluses.filter(function(d) {
         return commonbolus.isUnderride(d);
       });
 
       drawBolus.underride(underride);
 
-      // boluses where delivered > recommended
+      // boluses where programmed > recommended
       var override = boluses.filter(function(d) {
         return commonbolus.isOverride(d);
       });

--- a/test/commonbolus_test.js
+++ b/test/commonbolus_test.js
@@ -395,4 +395,106 @@ describe('common bolus functions', function() {
       expect(commonbolus.getMaxDuration(fixtures.immediatelyCancelledSquare)).to.equal(fixtures.immediatelyCancelledSquare.expectedDuration);
     });
   });
+
+  describe('isDifferentBeyondPrecision', function() {
+    it('should be a function', function() {
+      assert.isFunction(commonbolus.isDifferentBeyondPrecision);
+    });
+
+    it('should return false when not different beyond the precision arg', function() {
+      expect(commonbolus.isDifferentBeyondPrecision(1.0, 1.1, 0)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(2.00, 2.01, 1)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(2.01, 2.00, 1)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(3.01, 3.01, 0)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(3.01, 3.01, 1)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(3.01, 3.01, 2)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(3, 3, 0)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(3, 3, 1)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(3, 3, 2)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(3.08, 3.08, 1)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(3.08, 3.08, 2)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(3.08, 3.08, 3)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(3.08, 3.08, 4)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(4, 4.01, 1)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(4.01, 4, 1)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(5.010, 5.011, 2)).to.be.false;
+      expect(commonbolus.isDifferentBeyondPrecision(5.011, 5.010, 2)).to.be.false;
+    });
+
+    it('should return true when different beyond the precision arg', function() {
+      expect(commonbolus.isDifferentBeyondPrecision(1, 2, 0)).to.be.true;
+      expect(commonbolus.isDifferentBeyondPrecision(1, 2, 1)).to.be.true;
+      expect(commonbolus.isDifferentBeyondPrecision(1, 2, 2)).to.be.true;
+      expect(commonbolus.isDifferentBeyondPrecision(2, 1, 0)).to.be.true;
+      expect(commonbolus.isDifferentBeyondPrecision(2, 1, 1)).to.be.true;
+      expect(commonbolus.isDifferentBeyondPrecision(2, 1, 2)).to.be.true;
+      expect(commonbolus.isDifferentBeyondPrecision(3.00, 2.00, 0)).to.be.true;
+      expect(commonbolus.isDifferentBeyondPrecision(3.00, 2.00, 1)).to.be.true;
+      expect(commonbolus.isDifferentBeyondPrecision(3.00, 2.00, 2)).to.be.true;
+      expect(commonbolus.isDifferentBeyondPrecision(4.1, 4.2, 1)).to.be.true;
+      expect(commonbolus.isDifferentBeyondPrecision(4.2, 4.1, 1)).to.be.true;
+      expect(commonbolus.isDifferentBeyondPrecision(5.01, 5.00, 2)).to.be.true;
+      expect(commonbolus.isDifferentBeyondPrecision(5.00, 5.01, 2)).to.be.true;
+    });
+  });
+
+  describe('isOverride', function() {
+    it('should be a function', function() {
+      assert.isFunction(commonbolus.isOverride);
+    });
+
+    it('should return true when Recommended is less than Programmed', function() {
+      expect(commonbolus.isOverride({
+        type: 'wizard',
+        bolus: { expectedExtended: 5.7, extended: 1.05, normal: 3.8, source: 'Insulet' },
+        recommended: { carb: 8.65, correction: 1.7, net: 8.55 },
+      })).to.be.true;
+    });
+
+    it('should return false when Recommended is the same as Programmed', function() {
+      expect(commonbolus.isOverride({
+        type: 'wizard',
+        bolus: { expectedExtended: 5.7, extended: 1.05, normal: 3.8, source: 'Insulet' },
+        recommended: { carb: 8.65, correction: 0.9, net: 9.5 },
+      })).to.be.false;
+    });
+
+    it('should return false when Recommended is greater than Programmed', function() {
+      expect(commonbolus.isOverride({
+        type: 'wizard',
+        bolus: { expectedExtended: 5.7, extended: 1.05, normal: 3.8, source: 'Insulet' },
+        recommended: { carb: 8.65, correction: 0.9, net: 10.8 },
+      })).to.be.false;
+    });
+  });
+
+  describe('isUnderride', function() {
+    it('should be a function', function() {
+      assert.isFunction(commonbolus.isDifferentBeyondPrecision);
+    });
+
+    it('should return true when Recommended is greater than Programmed', function() {
+      expect(commonbolus.isUnderride({
+        type: 'wizard',
+        bolus: { normal: 2, type: 'bolus', source: 'Medtronic' },
+        recommended: { carb: 2.8, correction: 0.2, net: 3 },
+      })).to.be.true;
+    });
+
+    it('should return false when Recommended equals Programmed', function() {
+      expect(commonbolus.isUnderride({
+        type: 'wizard',
+        bolus: { normal: 3, type: 'bolus', source: 'Medtronic' },
+        recommended: { carb: 2.8, correction: 0.2, net: 3 },
+      })).to.be.false;
+    });
+
+    it('should return false when Recommended is less than Programmed', function() {
+      expect(commonbolus.isUnderride({
+        type: 'wizard',
+        bolus: { normal: 4, type: 'bolus', source: 'Medtronic' },
+        recommended: { carb: 2.8, correction: 0.2, net: 3 },
+      })).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
[WEB-3399]

This PR aligns the tooltip with the chart, so that the both will be in agreement about whether a bolus event is an override/underride or if it is not. Per the ticket, I have changed the chart to not consider it an override if the discrepancy is < 0.01, which is how the tooltip works already.

The important note is that I've changed the comparison in the chart from `Recommended vs Delivered` to `Recommended vs Programmed`, which is the comparison that the tooltip makes already. This makes more sense in my head than switching the tooltip to compare `Recommended vs Delivered`, but let me know if it's not accurate.

Before:

![Screenshot 2025-02-26 at 11 34 58](https://github.com/user-attachments/assets/75474fd0-0545-49ab-94af-7b6d79956598)

After:

![Screenshot 2025-02-26 at 11 34 42](https://github.com/user-attachments/assets/338c59d9-78a5-48ff-913a-81c707220b26)




[WEB-3399]: https://tidepool.atlassian.net/browse/WEB-3399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ