### PR TITLE
[WEB-3546] Render extended bolusus under other boluses of same height

### DIFF
--- a/js/data/util/constants.js
+++ b/js/data/util/constants.js
@@ -32,6 +32,10 @@ module.exports = {
       [PHYSICAL_ACTIVITY]: { label: t('Workout'), marker: t('W') },
       [PREPRANDIAL]: { label: t('Premeal'), marker: t('P') },
     },
+    [constants.TWIIST_LOOP.toLowerCase()]: {
+      [PHYSICAL_ACTIVITY]: { label: t('Workout'), marker: t('W') },
+      [PREPRANDIAL]: { label: t('Premeal'), marker: t('P') },
+    },
   },
   SCHEDULED_BASAL_LABELS: {
     Medtronic: t('Manual'),

--- a/js/plot/quickbolus.js
+++ b/js/plot/quickbolus.js
@@ -62,8 +62,8 @@ module.exports = function(pool, opts) {
         // in cases where the max value is the same, tiebreak the sort by counting extended boluses
         // as 1 unit higher so that a non-extended bolus is drawn on top, enabling both to be hovered over
         const maxValue = {
-          a: commonbolus.getMaxValue(a) + a.tags?.extended ? 1 : 0,
-          b: commonbolus.getMaxValue(b) + b.tags?.extended ? 1 : 0,
+          a: commonbolus.getMaxValue(a) + (a.tags?.extended ? 1 : 0),
+          b: commonbolus.getMaxValue(b) + (b.tags?.extended ? 1 : 0),
         };
 
         return d3.descending(maxValue.a, maxValue.b);

--- a/js/plot/quickbolus.js
+++ b/js/plot/quickbolus.js
@@ -59,7 +59,14 @@ module.exports = function(pool, opts) {
 
       // sort by size so smaller boluses are drawn last
       bolusGroups = bolusGroups.sort(function(a,b){
-        return d3.descending(commonbolus.getMaxValue(a), commonbolus.getMaxValue(b));
+        // in cases where the max value is the same, tiebreak the sort by counting extended boluses
+        // as 1 unit higher so that a non-extended bolus is drawn on top, enabling both to be hovered over
+        const maxValue = {
+          a: commonbolus.getMaxValue(a) + a.tags.extended ? 1 : 0,
+          b: commonbolus.getMaxValue(b) + b.tags.extended ? 1 : 0,
+        };
+
+        return d3.descending(maxValue.a, maxValue.b);
       });
 
       drawBolus.bolus(bolusGroups.filter(function(d) {

--- a/js/plot/quickbolus.js
+++ b/js/plot/quickbolus.js
@@ -62,8 +62,8 @@ module.exports = function(pool, opts) {
         // in cases where the max value is the same, tiebreak the sort by counting extended boluses
         // as 1 unit higher so that a non-extended bolus is drawn on top, enabling both to be hovered over
         const maxValue = {
-          a: commonbolus.getMaxValue(a) + a.tags.extended ? 1 : 0,
-          b: commonbolus.getMaxValue(b) + b.tags.extended ? 1 : 0,
+          a: commonbolus.getMaxValue(a) + a.tags?.extended ? 1 : 0,
+          b: commonbolus.getMaxValue(b) + b.tags?.extended ? 1 : 0,
         };
 
         return d3.descending(maxValue.a, maxValue.b);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.30.1-rc.2",
+  "version": "1.30.1-rc.3",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/basics/logic/constants.js
+++ b/plugins/blip/basics/logic/constants.js
@@ -14,7 +14,7 @@ module.exports = {
   INSULET: 'Insulet',
   MICROTECH: 'Microtech',
   TIDEPOOL_LOOP: 'Tidepool Loop',
-  TWIIST_LOOP: 'Twiist',
+  TWIIST_LOOP: 'twiist',
   DIY_LOOP: 'DIY Loop',
   TANDEM: 'Tandem',
   ANIMAS: 'Animas',

--- a/test/constants_test.js
+++ b/test/constants_test.js
@@ -66,6 +66,10 @@ describe('constants', function() {
         physicalActivity: { label: 'Workout', marker: 'W' },
         preprandial: { label: 'Premeal', marker: 'P' },
       },
+      twiist: {
+        physicalActivity: { label: 'Workout', marker: 'W' },
+        preprandial: { label: 'Premeal', marker: 'P' },
+      },
     });
   });
 


### PR DESCRIPTION
[WEB-3546]

The boluses were already being rendered in order of max-height.  In the case of the issue spotted in the ticket, it was actually a matter of them being exactly the same max height, and so the ordering needed a tie-breaker to ensure that in such cases, the extended would be drawn first, and so rendered on the  bottom.

Related PR: https://github.com/tidepool-org/blip/pull/1558