### PR TITLE
[WEB-2960] Sanitize user name and messages in notes tooltip previews

### DIFF
--- a/js/plot/message.js
+++ b/js/plot/message.js
@@ -17,6 +17,7 @@
 
 var d3 = require('d3');
 var _ = require('lodash');
+var { sanitize } = require('dompurify');
 
 var format = require('../data/util/format');
 
@@ -128,7 +129,7 @@ module.exports = function(pool, opts) {
       .attr('class', 'messageTooltip')
       .append('span')
       .attr('class', 'secondary')
-      .html('<span class="value">' + format.nameForDisplay(d.user.fullName) + '</span> ' + format.textPreview(d.messageText));
+      .html('<span class="value">' + sanitize(format.nameForDisplay(d.user.fullName)) + '</span> ' + sanitize(format.textPreview(d.messageText)));
 
     var dims = tooltips.foreignObjDimensions(foGroup);
     // foGroup.node().parentNode is the <foreignObject> itself

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.31.0-rc.5",
+  "version": "1.31.0-rc.7",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "crossfilter": "1.3.12",
     "d3": "3.5.17",
     "d3.chart": "0.3.0",
+    "dompurify": "3.2.5",
     "duration-js": "4.0.0",
     "i18next": "23.6.0",
     "intl": "1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,6 +2108,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
+  languageName: node
+  linkType: hard
+
 "@types/yauzl@npm:^2.9.1":
   version: 2.10.1
   resolution: "@types/yauzl@npm:2.10.1"
@@ -4151,6 +4158,18 @@ __metadata:
   dependencies:
     domelementtype: ^2.3.0
   checksum: 0f58f4a6af63e6f3a4320aa446d28b5790a009018707bce2859dcb1d21144c7876482b5188395a188dfa974238c019e0a1e610d2fc269a12b2c192ea2b0b131c
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:3.2.5":
+  version: 3.2.5
+  resolution: "dompurify@npm:3.2.5"
+  dependencies:
+    "@types/trusted-types": ^2.0.7
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: bd3b40810cc74312970dc6b99d38450ec839c81fb56c27d2c1b815ce0206b73e9cd4fe2e9021f735a1aaebf017990a63e6454e7d9c893f72b365b94d030ec9c4
   languageName: node
   linkType: hard
 
@@ -9482,6 +9501,7 @@ __metadata:
     css-loader: 6.8.1
     d3: 3.5.17
     d3.chart: 0.3.0
+    dompurify: 3.2.5
     duration-js: 4.0.0
     enzyme: 3.11.0
     enzyme-adapter-react-16: 1.15.7


### PR DESCRIPTION
[WEB-2960]

Noticed while working on the js error fix that these tooltip previews were not being sanitized

Related PR: https://github.com/tidepool-org/blip/pull/1572

[WEB-2960]: https://tidepool.atlassian.net/browse/WEB-2960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ