### PR TITLE
[WEB-3698] Set recommended bolus back to amount

### DIFF
--- a/js/plot/util/commonbolus.js
+++ b/js/plot/util/commonbolus.js
@@ -40,12 +40,8 @@ module.exports = {
     }
 
     var rec = 0;
-    if (event.recommended?.carb) {
-      rec += event.recommended.carb;
-    }
-    if (event.recommended?.correction) {
-      rec += event.recommended.correction;
-    }
+    rec += _.get(event, ['recommended', 'carb'], 0);
+    rec += _.get(event, ['recommended', 'correction'], 0);
 
     return format.fixFloatingPoint(rec);
   },

--- a/js/plot/util/commonbolus.js
+++ b/js/plot/util/commonbolus.js
@@ -32,7 +32,7 @@ module.exports = {
     }
 
     const netRecommendation = event.recommendedBolus
-      ? _.get(event, ['recommendedBolus', 'normal'], null)
+      ? _.get(event, ['recommendedBolus', 'amount'], null)
       : _.get(event, ['recommended', 'net'], null);
 
     if (netRecommendation != null) {

--- a/js/plot/util/commonbolus.js
+++ b/js/plot/util/commonbolus.js
@@ -40,10 +40,10 @@ module.exports = {
     }
 
     var rec = 0;
-    if (event.recommended.carb) {
+    if (event.recommended?.carb) {
       rec += event.recommended.carb;
     }
-    if (event.recommended.correction) {
+    if (event.recommended?.correction) {
       rec += event.recommended.correction;
     }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.32.1-web-3698-dosing-decision-bolus-normal",
+  "version": "1.33.0-web-3687-new-dosing-decision-extended-duration-props.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/test/commonbolus_test.js
+++ b/test/commonbolus_test.js
@@ -136,7 +136,7 @@ describe('common bolus functions', function() {
       expectedNormal: 6,
       insulinOnBoard: 2.654,
       dosingDecision: {
-        recommendedBolus: { normal: 1.5 },
+        recommendedBolus: { amount: 1.5 },
       },
     },
   };
@@ -176,7 +176,7 @@ describe('common bolus functions', function() {
     });
 
     it('should return net rec when net rec exists within dosingDecision', function() {
-      expect(commonbolus.getRecommended(fixtures.withDosingDecision)).to.equal(fixtures.withDosingDecision.dosingDecision.recommendedBolus.normal);
+      expect(commonbolus.getRecommended(fixtures.withDosingDecision)).to.equal(fixtures.withDosingDecision.dosingDecision.recommendedBolus.amount);
     });
   });
 


### PR DESCRIPTION
[WEB-3698]
Reverted the recommendedBolus.normal back to recommendedBolus.amount in light of new insights for twiist data.

[WEB-3698]: https://tidepool.atlassian.net/browse/WEB-3698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ