### PR TITLE
[WEB-3791] Remove calls to previously removed isUnderride and isOverride utility functions

### DIFF
--- a/js/plot/wizard.js
+++ b/js/plot/wizard.js
@@ -87,28 +87,28 @@ module.exports = function(pool, opts) {
       drawBolus.bolus(boluses);
 
       var extended = boluses.filter(function(d) {
-        return d.bolus.extended || d.bolus.expectedExtended;
+        return d.tags?.extended;
       });
 
       drawBolus.extended(extended);
 
       // boluses where recommended > programmed
       var underride = boluses.filter(function(d) {
-        return commonbolus.isUnderride(d);
+        return d.tags?.underride;
       });
 
       drawBolus.underride(underride);
 
       // boluses where programmed > recommended
       var override = boluses.filter(function(d) {
-        return commonbolus.isOverride(d);
+        return d.tags?.override;
       });
 
       drawBolus.override(override);
 
       // boluses where programmed differs from delivered
       var suspended = boluses.filter(function(d) {
-        return commonbolus.getDelivered(d) !== commonbolus.getProgrammed(d);
+        return d.tags?.interrupted;
       });
 
       drawBolus.suspended(suspended);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.33.1-rc.1",
+  "version": "1.33.1-rc.2",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",


### PR DESCRIPTION
[WEB-3791] This was done for the bolus datum rendering in a [previous PR](https://github.com/tidepool-org/tideline/pull/481/files#diff-1ff153525c26b164ce77e55e7cdf1a40f05ae89deec2fc4a797b815477964d54) for `quickBolus.js`, but I missed also updating the same checks for the wizard rendering file (`wizard.js`).

[WEB-3791]: https://tidepool.atlassian.net/browse/WEB-3791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ