### PR TITLE
[WEB-3886] Show correct site change source labels for twiist pumps on Basics web view

### DIFF
--- a/js/data/util/device.js
+++ b/js/data/util/device.js
@@ -29,4 +29,17 @@ module.exports = {
   isAutomatedBasalDevice: (pumpUpload = {}) => {
     return _.includes(_.get(AUTOMATED_BASAL_DEVICE_MODELS, pumpUpload.source, []), pumpUpload.deviceModel);
   },
+
+  getUppercasedManufacturer: (manufacturer = '') => {
+    return _.map(manufacturer.split(' '), part => {
+      switch (part) {
+        case 'diy':
+          return _.upperCase(part);
+        case 'twiist':
+          return part;
+        default:
+          return _.upperFirst(part);
+      }
+    }).join(' ');
+  },
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.38.0-web-1463-dexcom-events.1",
+  "version": "1.38.0-web-3886-basics-view-site-change-regression.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/plugins/blip/basics/components/sitechange/Selector.js
+++ b/plugins/blip/basics/components/sitechange/Selector.js
@@ -25,6 +25,7 @@ var cx = require('classnames');
 
 var basicsActions = require('../../logic/actions');
 var BasicsUtils = require('../BasicsUtils');
+var { getUppercasedManufacturer } = require('../../../../../js/data/util/device');
 
 var constants = require('../../logic/constants');
 
@@ -137,7 +138,7 @@ var Selector = createReactClass({
       }
     };
 
-    const manufacturer = _.capitalize(_.get(pump, 'manufacturer', ''));
+    const manufacturer = getUppercasedManufacturer(_.get(pump, 'manufacturer', ''));
 
     if (pumpVocabulary.hasOwnProperty(manufacturer)) {
       return (


### PR DESCRIPTION
[WEB-3886] 

Related PR: https://github.com/tidepool-org/blip/pull/1836

Needed to add a function to normalize manufacturer names for consistent dictionary lookups against the pumpVocabulary and settingsOverrides objects in constants.js.  We did this in viz in the past, but missed doing it here which is why twiist was only rendering the correct labels in the PDF and not the web view.

Why it's needed (here or in viz):
1. Inconsistent casing in source data: Manufacturer names coming from device data may be lowercase (e.g., 'diy loop', 'twiist', 'tandem'), but the lookup keys in the constants objects use specific casing conventions based on how we want them presented to the end user.
2. Different capitalization rules per manufacturer:
   - 'diy' → 'DIY' (fully uppercased, as it's an acronym)
   - 'twiist' → 'twiist' (kept lowercase, it's a brand name styled that way)
   - Everything else → 'Tandem', 'Medtronic' (standard title case via _.upperFirst)
3. Multi-word manufacturer names: The function splits on spaces and applies the appropriate transformation to each word, then rejoins them. For example, 'diy loop' becomes 'DIY Loop'.

[WEB-3886]: https://tidepool.atlassian.net/browse/WEB-3886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ