### PR TITLE
[WEB-4597] Fix struck-through original carb value + render edited net-0 carbs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ coverage/
 !.yarn/versions
 
 .opencode
+
+# ApoVault — ignore entire vault (per /apo:init choice 2026-05-25)
+.apo/
+.pi
+.pi-lens

--- a/js/plot/carb.js
+++ b/js/plot/carb.js
@@ -34,10 +34,16 @@ module.exports = function(pool, opts) {
 
   const xPos = (d) => opts.xScale(d.normalTime);
 
-  // Original carb value from either dosingDecision path (mirrors FoodTooltip.js logic)
-  const getOriginalCarbs = (d) =>
-    d?.dosingDecision?.originalFood?.nutrition?.carbohydrate?.net
-    ?? d?.originalDosingDecision?.food?.nutrition?.carbohydrate?.net;
+  // True initial carb value, mirroring FoodTooltip.js / DataUtil.js exactly: read the
+  // EARLIEST dosing decision's immutable `originalFood` snapshot, falling back to its
+  // `food`. The latest dosingDecision has no `originalFood` on multi-edit chains, and
+  // intermediate decisions' `food` has been rewritten to the final value -- so reading
+  // either of those would surface the post-edit number instead of the initial one.
+  const getOriginalCarbs = (d) => {
+    const earliestDosingDecision = d?.originalDosingDecision || d?.dosingDecision;
+    return earliestDosingDecision?.originalFood?.nutrition?.carbohydrate?.net
+      ?? earliestDosingDecision?.food?.nutrition?.carbohydrate?.net;
+  };
 
   // tags.carbsEdited: true → oblong showing original (struck through) + current value
   const hasCarbsEdited = (d) => d?.tags?.carbsEdited === true;
@@ -185,6 +191,9 @@ module.exports = function(pool, opts) {
       });
     }
   };
+
+  // Exposed for unit testing the initial-carb derivation in isolation.
+  carb.getOriginalCarbs = getOriginalCarbs;
 
   return carb;
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "24.15.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.39.0-web-4597-edited-carb-qa-feedback.1",
+  "version": "1.39.0-rc.2",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "24.15.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.39.0-rc.1",
+  "version": "1.39.0-web-4597-edited-carb-qa-feedback.1",
   "description": "Tidepool's timeline data visualization",
   "repository": {
     "type": "git",

--- a/test/carb_test.js
+++ b/test/carb_test.js
@@ -1,0 +1,54 @@
+var chai = require('chai');
+var expect = chai.expect;
+
+var carbFactory = require('../js/plot/carb');
+
+// A minimal pool stub is enough: the factory only reads pool/opts lazily inside
+// carb(selection); constructing the renderer just wires up the closures we test.
+var carb = carbFactory({}, {});
+
+var food = (net) => ({ nutrition: { carbohydrate: { net: net } } });
+
+describe('carb plot getOriginalCarbs', function() {
+  it('reads the EARLIEST dosing decision’s originalFood on a multi-edit chain (25→35→44 → 25, not the stale 44)', function() {
+    var datum = {
+      nutrition: { carbohydrate: { net: 44 } }, // final
+      // earliest decision keeps the true initial entry in originalFood; its food has
+      // been rewritten to the final value (stale)
+      originalDosingDecision: { originalFood: food(25), food: food(44) },
+      // latest decision carries no originalFood on a multi-edit chain
+      dosingDecision: { food: food(44) },
+    };
+    expect(carb.getOriginalCarbs(datum)).to.equal(25);
+  });
+
+  it('returns the original amount for a single edit (60→50 → 60)', function() {
+    var datum = {
+      nutrition: { carbohydrate: { net: 50 } },
+      originalDosingDecision: { originalFood: food(60), food: food(50) },
+      dosingDecision: { food: food(50), originalFood: food(60) },
+    };
+    expect(carb.getOriginalCarbs(datum)).to.equal(60);
+  });
+
+  it('returns the pre-deletion amount when only one dosing decision exists (delete 30→0 → 30)', function() {
+    var datum = {
+      nutrition: { carbohydrate: { net: 0 } },
+      dosingDecision: { originalFood: food(30), food: food(0) },
+    };
+    expect(carb.getOriginalCarbs(datum)).to.equal(30);
+  });
+
+  it('falls back to the earliest decision’s food when it has no originalFood', function() {
+    var datum = {
+      nutrition: { carbohydrate: { net: 35 } },
+      originalDosingDecision: { food: food(35) },
+      dosingDecision: { food: food(35) },
+    };
+    expect(carb.getOriginalCarbs(datum)).to.equal(35);
+  });
+
+  it('returns undefined when no dosing decisions are present', function() {
+    expect(carb.getOriginalCarbs({ nutrition: { carbohydrate: { net: 20 } } })).to.equal(undefined);
+  });
+});


### PR DESCRIPTION
[WEB-4597] 

Related PRs:
https://github.com/tidepool-org/blip/pull/1940
https://github.com/tidepool-org/viz/pull/641

**Changes:**
- **`getOriginalCarbs`** reads the *earliest* decision (`originalDosingDecision.originalFood ?? .food`) so the struck-through "original" is the initial amount, not the final value. Exposed as `carb.getOriginalCarbs` for testing.
- **Draw filter** is now `net > 0 || tags.carbsEdited`, so a carb edited down to / deleted at `0` still draws (original struck over `0`).

**Out of scope:** deleted Loop carbs still don't render — upstream data gap (no surviving food/deletion record, unlike twiist).


[WEB-4597]: https://tidepool.atlassian.net/browse/WEB-4597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ